### PR TITLE
[WIP] Compress log files using pixz (indexed xz)

### DIFF
--- a/client/client.ml
+++ b/client/client.ml
@@ -173,7 +173,8 @@ let add_user_cmd ~confdir ~conffile =
 
 let init ~confdir ~conffile = function
   | Some local_workdir ->
-      let local_workdir = Server_workdirs.create ~workdir:local_workdir in
+      let cwd = Sys.getcwd () in
+      let local_workdir = Server_workdirs.create ~cwd ~workdir:local_workdir in
       let server_conf = Server_configfile.from_workdir local_workdir in
       let profilename = Server_configfile.name server_conf in
       let hostname = Oca_lib.localhost in

--- a/lib/dune
+++ b/lib/dune
@@ -7,6 +7,5 @@
     opam-core
     yaml
     fpath
-    lz4
     uri
     containers))

--- a/lib/intf.ml
+++ b/lib/intf.ml
@@ -73,24 +73,11 @@ module Repository = struct
 end
 
 module Log = struct
-  type t =
-    | Compressed of bytes Lwt.t
-    | Unstored of (unit -> string Lwt.t)
+  type t = (unit -> string Lwt.t)
 
-  let compressed_buffer_len = ref 0
+  let create f = f
 
-  let compressed s =
-    let s =
-      s >|= fun s ->
-      compressed_buffer_len := max !compressed_buffer_len (String.length s);
-      LZ4.Bytes.compress (Bytes.unsafe_of_string s)
-    in
-    Compressed s
-  let unstored f = Unstored f
-
-  let to_string = function
-    | Compressed s -> s >|= fun s -> Bytes.unsafe_to_string (LZ4.Bytes.decompress ~length:!compressed_buffer_len s)
-    | Unstored f -> f ()
+  let to_string f = f ()
 end
 
 module Instance = struct

--- a/lib/intf.mli
+++ b/lib/intf.mli
@@ -44,8 +44,7 @@ end
 module Log : sig
   type t
 
-  val compressed : string Lwt.t -> t
-  val unstored : (unit -> string Lwt.t) -> t
+  val create : (unit -> string Lwt.t) -> t
 end
 
 module Instance : sig

--- a/lib/oca_lib.ml
+++ b/lib/oca_lib.ml
@@ -78,7 +78,7 @@ let random_access_tpxz_archive ~file archive =
   pread ~timeout:60. ["sh"; "-c"; "pixz -x "^file^" -i "^archive^" | tar -xO"] (Lwt_io.read ?count:None)
 
 let compress_tpxz_archive ~directories archive =
-  pread ~timeout:60. ("tar" :: "-Ipixz" :: "-cf" :: Fpath.to_string archive :: List.map Fpath.to_string directories) begin fun _ ->
+  pread ~timeout:3600. ("tar" :: "-Ipixz" :: "-cf" :: Fpath.to_string archive :: List.map Fpath.to_string directories) begin fun _ ->
     (* TODO: Do not use pread *)
     Lwt.return ()
   end

--- a/lib/oca_lib.ml
+++ b/lib/oca_lib.ml
@@ -41,8 +41,11 @@ let rec scan_dir dirname =
   Lwt_list.fold_left_s (fun acc file ->
     let file = Fpath.add_seg dirname file in
     Lwt_unix.stat (Fpath.to_string file) >>= function
-    | {Unix.st_kind = Unix.S_DIR; _} -> scan_dir file >|= fun files -> files @ acc
-    | {Unix.st_kind = Unix.S_REG; _} -> Lwt.return (Fpath.to_string file :: acc)
+    | {Unix.st_kind = Unix.S_DIR; _} ->
+        scan_dir file >|= fun files ->
+        Fpath.to_string (Fpath.add_seg file "") :: files @ acc
+    | {Unix.st_kind = Unix.S_REG; _} ->
+        Lwt.return (Fpath.to_string file :: acc)
     | _ -> assert false
   ) [] files
 

--- a/lib/oca_lib.ml
+++ b/lib/oca_lib.ml
@@ -37,7 +37,7 @@ let get_files dirname =
   files
 
 let rec scan_dir ~full_path dirname =
-  get_files dirname >>= fun files ->
+  get_files full_path >>= fun files ->
   Lwt_list.fold_left_s (fun acc file ->
     let full_path = Fpath.add_seg full_path file in
     let file = Fpath.normalize (Fpath.add_seg dirname file) in

--- a/lib/oca_lib.mli
+++ b/lib/oca_lib.mli
@@ -8,6 +8,8 @@ val scan_dir : Fpath.t -> string list Lwt.t
 val scan_tpxz_archive : Fpath.t -> string list Lwt.t
 val random_access_tpxz_archive : file:string -> Fpath.t -> string Lwt.t
 val compress_tpxz_archive : cwd:Fpath.t -> directories:string list -> Fpath.t -> unit Lwt.t
+val ugrep_dir : switch:string -> regexp:string -> cwd:Fpath.t -> string list Lwt.t
+val ugrep_tpxz : switch:string -> regexp:string -> archive:Fpath.t -> string list Lwt.t
 val mkdir_p : Fpath.t -> unit Lwt.t
 val rm_rf : Fpath.t -> unit Lwt.t
 

--- a/lib/oca_lib.mli
+++ b/lib/oca_lib.mli
@@ -4,6 +4,10 @@ val is_valid_filename : string -> bool
 val char_is_docker_compatible : char -> bool
 
 val get_files : Fpath.t -> string list Lwt.t
+val scan_dir : Fpath.t -> string list Lwt.t
+val scan_tpxz_archive : Fpath.t -> string list Lwt.t
+val random_access_tpxz_archive : file:string -> Fpath.t -> string Lwt.t
+val compress_tpxz_archive : directories:Fpath.t list -> Fpath.t -> unit Lwt.t
 val mkdir_p : Fpath.t -> unit Lwt.t
 val rm_rf : Fpath.t -> unit Lwt.t
 

--- a/lib/oca_lib.mli
+++ b/lib/oca_lib.mli
@@ -7,7 +7,7 @@ val get_files : Fpath.t -> string list Lwt.t
 val scan_dir : Fpath.t -> string list Lwt.t
 val scan_tpxz_archive : Fpath.t -> string list Lwt.t
 val random_access_tpxz_archive : file:string -> Fpath.t -> string Lwt.t
-val compress_tpxz_archive : directories:Fpath.t list -> Fpath.t -> unit Lwt.t
+val compress_tpxz_archive : cwd:Fpath.t -> directories:string list -> Fpath.t -> unit Lwt.t
 val mkdir_p : Fpath.t -> unit Lwt.t
 val rm_rf : Fpath.t -> unit Lwt.t
 

--- a/lib/server_configfile.ml
+++ b/lib/server_configfile.ml
@@ -9,7 +9,7 @@ type t = {
   mutable auto_run_interval : int option;
   mutable processes : int option;
   mutable enable_dune_cache : bool option;
-  mutable enable_in_memory_logs : bool option;
+  mutable enable_logs_compression : bool option;
   mutable extra_repositories : Intf.Repository.t list option;
   mutable with_test : bool option;
   mutable list_command : string option;
@@ -27,7 +27,7 @@ let create_conf yamlfile = {
   auto_run_interval = None;
   processes = None;
   enable_dune_cache = None;
-  enable_in_memory_logs = None;
+  enable_logs_compression = None;
   extra_repositories = None;
   with_test = None;
   list_command = None;
@@ -82,8 +82,8 @@ let set_config conf = function
       set_field ~field (fun () -> conf.auto_run_interval <- Some (int_of_float auto_run_interval)) conf.auto_run_interval
   | "enable-dune-cache" as field, `Bool dune_cache ->
       set_field ~field (fun () -> conf.enable_dune_cache <- Some dune_cache) conf.enable_dune_cache
-  | "enable-in-memory-logs" as field, `Bool in_memory_logs ->
-      set_field ~field (fun () -> conf.enable_in_memory_logs <- Some in_memory_logs) conf.enable_in_memory_logs
+  | "enable-logs-compression" as field, `Bool logs_compression ->
+      set_field ~field (fun () -> conf.enable_logs_compression <- Some logs_compression) conf.enable_logs_compression
   | "extra-repositories" as field, `A repositories ->
       let repositories = List.map get_repo repositories in
       set_field ~field (fun () -> conf.extra_repositories <- Some repositories) conf.extra_repositories
@@ -132,7 +132,7 @@ let yaml_of_conf conf =
     "auto-run-interval", `Float (float_of_int (Option.get_exn conf.auto_run_interval));
     "processes", `Float (float_of_int (Option.get_exn conf.processes));
     "enable-dune-cache", `Bool (Option.get_exn conf.enable_dune_cache);
-    "enable-in-memory-logs", `Bool (Option.get_exn conf.enable_in_memory_logs);
+    "enable-logs-compression", `Bool (Option.get_exn conf.enable_logs_compression);
     "extra-repositories", Option.map_or ~default:`Null yaml_of_extra_repositories conf.extra_repositories;
     "with-test", `Bool (Option.get_exn conf.with_test);
     "list-command", `String (Option.get_exn conf.list_command);
@@ -156,8 +156,8 @@ let set_defaults conf =
     conf.processes <- Some Oca_lib.default_processes;
   if Option.is_none conf.enable_dune_cache then
     conf.enable_dune_cache <- Some false; (* NOTE: Too unstable to enable by default *)
-  if Option.is_none conf.enable_in_memory_logs then
-    conf.enable_in_memory_logs <- Some false; (* NOTE: Requires too much memory for regular users *)
+  if Option.is_none conf.enable_logs_compression then
+    conf.enable_logs_compression <- Some true; (* NOTE: Requires too much disk space for regular users *)
   if Option.is_none conf.extra_repositories then
     conf.extra_repositories <- Some [Intf.Repository.create ~name:"beta" ~github:"ocaml/ocaml-beta-repository" ~for_switches:None];
   if Option.is_none conf.with_test then
@@ -226,7 +226,7 @@ let admin_port {admin_port; _} = Option.get_exn admin_port
 let auto_run_interval {auto_run_interval; _} = Option.get_exn auto_run_interval
 let processes {processes; _} = Option.get_exn processes
 let enable_dune_cache {enable_dune_cache; _} = Option.get_exn enable_dune_cache
-let enable_in_memory_logs {enable_in_memory_logs; _} = Option.get_exn enable_in_memory_logs
+let enable_logs_compression {enable_logs_compression; _} = Option.get_exn enable_logs_compression
 let extra_repositories {extra_repositories; _} = Option.get_exn extra_repositories
 let with_test {with_test; _} = Option.get_exn with_test
 let list_command {list_command; _} = Option.get_exn list_command

--- a/lib/server_configfile.mli
+++ b/lib/server_configfile.mli
@@ -9,7 +9,7 @@ val admin_port : t -> int
 val auto_run_interval : t -> int
 val processes : t -> int
 val enable_dune_cache : t -> bool
-val enable_in_memory_logs : t -> bool
+val enable_logs_compression : t -> bool
 val extra_repositories : t -> Intf.Repository.t list
 val with_test : t -> bool
 val list_command : t -> string

--- a/lib/server_workdirs.ml
+++ b/lib/server_workdirs.ml
@@ -8,8 +8,9 @@ let (/) path file =
   Fpath.(/) path file
 
 let (+) = Fpath.(+)
+let (//) = Fpath.(//)
 
-let create ~workdir = Fpath.v workdir
+let create ~cwd ~workdir = Fpath.v cwd // Fpath.v workdir
 
 let keysdir workdir = workdir/"keys"
 let keyfile ~username workdir = keysdir workdir/username+"key"

--- a/lib/server_workdirs.ml
+++ b/lib/server_workdirs.ml
@@ -34,7 +34,7 @@ let logdirs workdir =
         let logdir = base_logdir/dir in
         begin match String.split_on_char '.' hash with
         | [hash] -> Logdir (Uncompressed, float_of_string time, hash, workdir, Oca_lib.scan_dir logdir)
-        | [hash; "tpxz"] -> Logdir (Compressed, float_of_string time, hash, workdir, Oca_lib.scan_tpxz_archive logdir)
+        | [hash; "txz"] -> Logdir (Compressed, float_of_string time, hash, workdir, Oca_lib.scan_tpxz_archive logdir)
         | _ -> assert false
         end
     | _ -> assert false
@@ -87,7 +87,7 @@ let logdir_get_content ~comp ~state ~pkg = function
       let file = base_logdir workdir/get_logdir_name logdir/comp/state/pkg in
       Lwt_io.with_file ~mode:Lwt_io.Input (Fpath.to_string file) (Lwt_io.read ?count:None)
   | Logdir (Compressed, _, _, workdir, _) as logdir ->
-      let archive = base_logdir workdir/get_logdir_name logdir+"tpxz" in
+      let archive = base_logdir workdir/get_logdir_name logdir+"txz" in
       let comp = Intf.Compiler.to_string comp in
       let state = Intf.State.to_string state in
       let file = comp^"/"^state^"/"^pkg in
@@ -99,7 +99,7 @@ let tmpswitchlogdir ~switch logdir = tmplogdir logdir/Intf.Compiler.to_string sw
 let logdir_compress ~switches (Logdir (_, _, _, workdir, _) as logdir) =
   let cwd = tmplogdir logdir in
   let directories = List.map Intf.Compiler.to_string switches in
-  let archive = base_logdir workdir/get_logdir_name logdir+"tpxz" in
+  let archive = base_logdir workdir/get_logdir_name logdir+"txz" in
   Oca_lib.compress_tpxz_archive ~cwd ~directories archive
 
 let ilogdir workdir = workdir/"ilogs"

--- a/lib/server_workdirs.ml
+++ b/lib/server_workdirs.ml
@@ -95,9 +95,10 @@ let tmplogdir (Logdir (_, _, _, workdir, _) as logdir) = base_tmpdir workdir/get
 let tmpswitchlogdir ~switch logdir = tmplogdir logdir/Intf.Compiler.to_string switch
 
 let logdir_compress ~switches (Logdir (_, _, _, workdir, _) as logdir) =
-  let directories = List.map (fun switch -> tmpswitchlogdir ~switch logdir) switches in
+  let cwd = tmplogdir logdir in
+  let directories = List.map Intf.Compiler.to_string switches in
   let archive = base_logdir workdir/get_logdir_name logdir+"tpxz" in
-  Oca_lib.compress_tpxz_archive ~directories archive
+  Oca_lib.compress_tpxz_archive ~cwd ~directories archive
 
 let ilogdir workdir = workdir/"ilogs"
 let new_ilogfile ~start_time workdir = ilogdir workdir/Printf.sprintf "%.0f" start_time

--- a/lib/server_workdirs.ml
+++ b/lib/server_workdirs.ml
@@ -60,6 +60,7 @@ let get_files ~name ~switch (Logdir (_, _, _, _, files)) =
   files >|= fun files ->
   List.filter_map (fun file ->
     match String.split_on_char '/' file with
+    | [_switch; _name; ""] -> None
     | [switch'; name'; pkg] when String.equal switch switch' && String.equal name name' -> Some pkg
     | _ -> None
   ) files

--- a/lib/server_workdirs.ml
+++ b/lib/server_workdirs.ml
@@ -30,9 +30,10 @@ let logdirs workdir =
   List.map (fun dir ->
     match String.split_on_char '-' dir with
     | [time; hash] ->
+        let logdir = base_logdir/dir in
         begin match String.split_on_char '.' hash with
-        | [hash] -> Logdir (Uncompressed, float_of_string time, hash, workdir, Oca_lib.scan_dir (base_logdir/dir))
-        | [hash; "tpxz"] -> Logdir (Compressed, float_of_string time, hash, workdir, Oca_lib.scan_tpxz_archive (base_logdir/dir+"tpxz"))
+        | [hash] -> Logdir (Uncompressed, float_of_string time, hash, workdir, Oca_lib.scan_dir logdir)
+        | [hash; "tpxz"] -> Logdir (Compressed, float_of_string time, hash, workdir, Oca_lib.scan_tpxz_archive logdir)
         | _ -> assert false
         end
     | _ -> assert false

--- a/lib/server_workdirs.ml
+++ b/lib/server_workdirs.ml
@@ -10,7 +10,7 @@ let (/) path file =
 let (+) = Fpath.(+)
 let (//) = Fpath.(//)
 
-let create ~cwd ~workdir = Fpath.v cwd // Fpath.v workdir
+let create ~cwd ~workdir = Fpath.normalize (Fpath.v cwd // Fpath.v workdir)
 
 let keysdir workdir = workdir/"keys"
 let keyfile ~username workdir = keysdir workdir/username+"key"

--- a/lib/server_workdirs.ml
+++ b/lib/server_workdirs.ml
@@ -93,6 +93,14 @@ let logdir_get_content ~comp ~state ~pkg = function
       let file = comp^"/"^state^"/"^pkg in
       Oca_lib.random_access_tpxz_archive ~file archive
 
+let logdir_search ~switch ~regexp = function
+  | Logdir (Uncompressed, _, _, workdir, _) as logdir ->
+      let cwd = base_logdir workdir/get_logdir_name logdir in
+      Oca_lib.ugrep_dir ~switch ~regexp ~cwd
+  | Logdir (Compressed, _, _, workdir, _) as logdir ->
+      let archive = base_logdir workdir/get_logdir_name logdir+"txz" in
+      Oca_lib.ugrep_tpxz ~switch ~regexp ~archive
+
 let tmplogdir (Logdir (_, _, _, workdir, _) as logdir) = base_tmpdir workdir/get_logdir_name logdir/"logs"
 let tmpswitchlogdir ~switch logdir = tmplogdir logdir/Intf.Compiler.to_string switch
 

--- a/lib/server_workdirs.mli
+++ b/lib/server_workdirs.mli
@@ -23,6 +23,7 @@ val internalfailurefiles : switch:Intf.Compiler.t -> logdir -> string list Lwt.t
 val logdir_get_content : comp:Intf.Compiler.t -> state:Intf.State.t -> pkg:string -> logdir -> string Lwt.t
 val logdir_get_compilers : logdir -> Intf.Compiler.t list Lwt.t
 val logdir_compress : switches:Intf.Compiler.t list -> logdir -> unit Lwt.t
+val logdir_search : switch:string -> regexp:string -> logdir -> string list Lwt.t
 
 val ilogdir : t -> Fpath.t
 val new_ilogfile : start_time:float -> t -> Fpath.t

--- a/lib/server_workdirs.mli
+++ b/lib/server_workdirs.mli
@@ -1,6 +1,6 @@
 type t
 
-val create : workdir:string -> t
+val create : cwd:string -> workdir:string -> t
 
 val keysdir : t -> Fpath.t
 val keyfile : username:string -> t -> Fpath.t

--- a/lib/server_workdirs.mli
+++ b/lib/server_workdirs.mli
@@ -9,26 +9,24 @@ type logdir
 
 val new_logdir : hash:string -> start_time:float -> t -> logdir
 val logdirs : t -> logdir list Lwt.t
-val tmplogdir : logdir -> Fpath.t
 
-val logdir_from_string : t -> string -> logdir
 val logdir_equal : logdir -> logdir -> bool
 val get_logdir_name : logdir -> string
-val get_logdir_path : logdir -> Fpath.t
 val get_logdir_hash : logdir -> string
 val get_logdir_time : logdir -> float
+
+val goodfiles : switch:Intf.Compiler.t -> logdir -> string list Lwt.t
+val partialfiles : switch:Intf.Compiler.t -> logdir -> string list Lwt.t
+val badfiles : switch:Intf.Compiler.t -> logdir -> string list Lwt.t
+val notavailablefiles : switch:Intf.Compiler.t -> logdir -> string list Lwt.t
+val internalfailurefiles : switch:Intf.Compiler.t -> logdir -> string list Lwt.t
+val logdir_get_content : comp:Intf.Compiler.t -> state:Intf.State.t -> pkg:string -> logdir -> string Lwt.t
+val logdir_get_compilers : logdir -> Intf.Compiler.t list Lwt.t
+val logdir_compress : switches:Intf.Compiler.t list -> logdir -> unit Lwt.t
 
 val ilogdir : t -> Fpath.t
 val new_ilogfile : start_time:float -> t -> Fpath.t
 
-val switchlogdir : switch:Intf.Compiler.t -> logdir -> Fpath.t
-val gooddir : switch:Intf.Compiler.t -> logdir -> Fpath.t
-val partialdir : switch:Intf.Compiler.t -> logdir -> Fpath.t
-val baddir : switch:Intf.Compiler.t -> logdir -> Fpath.t
-val notavailabledir : switch:Intf.Compiler.t -> logdir -> Fpath.t
-val internalfailuredir : switch:Intf.Compiler.t -> logdir -> Fpath.t
-
-val tmpswitchlogdir : switch:Intf.Compiler.t -> logdir -> Fpath.t
 val tmplogfile : pkg:string -> switch:Intf.Compiler.t -> logdir -> Fpath.t
 
 val tmpgoodlog : pkg:string -> switch:Intf.Compiler.t -> logdir -> Fpath.t
@@ -50,7 +48,6 @@ val tmprevdepsdir : logdir -> Fpath.t
 val tmprevdepsfile : pkg:string -> logdir -> Fpath.t
 
 val configfile : t -> Fpath.t
-val file_from_logdir : file:string -> logdir -> Fpath.t
 
 val init_base : t -> unit Lwt.t
 val init_base_jobs : switches:Intf.Switch.t list -> logdir -> unit Lwt.t

--- a/lib/server_workdirs.mli
+++ b/lib/server_workdirs.mli
@@ -7,7 +7,7 @@ val keyfile : username:string -> t -> Fpath.t
 
 type logdir
 
-val new_logdir : hash:string -> start_time:float -> t -> logdir
+val new_logdir : compressed:bool -> hash:string -> start_time:float -> t -> logdir
 val logdirs : t -> logdir list Lwt.t
 
 val logdir_equal : logdir -> logdir -> bool
@@ -22,7 +22,7 @@ val notavailablefiles : switch:Intf.Compiler.t -> logdir -> string list Lwt.t
 val internalfailurefiles : switch:Intf.Compiler.t -> logdir -> string list Lwt.t
 val logdir_get_content : comp:Intf.Compiler.t -> state:Intf.State.t -> pkg:string -> logdir -> string Lwt.t
 val logdir_get_compilers : logdir -> Intf.Compiler.t list Lwt.t
-val logdir_compress : switches:Intf.Compiler.t list -> logdir -> unit Lwt.t
+val logdir_move : switches:Intf.Compiler.t list -> logdir -> unit Lwt.t
 val logdir_search : switch:string -> regexp:string -> logdir -> string list Lwt.t
 
 val ilogdir : t -> Fpath.t

--- a/lib/server_workdirs.mli
+++ b/lib/server_workdirs.mli
@@ -27,6 +27,7 @@ val logdir_compress : switches:Intf.Compiler.t list -> logdir -> unit Lwt.t
 val ilogdir : t -> Fpath.t
 val new_ilogfile : start_time:float -> t -> Fpath.t
 
+val tmplogdir : logdir -> Fpath.t
 val tmplogfile : pkg:string -> switch:Intf.Compiler.t -> logdir -> Fpath.t
 
 val tmpgoodlog : pkg:string -> switch:Intf.Compiler.t -> logdir -> Fpath.t

--- a/opam-health-check.opam
+++ b/opam-health-check.opam
@@ -33,5 +33,6 @@ depends: [
   "tls" {>= "0.12.0"} # activate conduit with TLS for slack webhooks
   "conf-libev" # Required for lwt to avoid hitting the limits of select(2)
   "conf-pixz" # TODO: Make it a library
+  # TODO: Add conf-ugrep
 ]
 synopsis: "A toolchain to check for broken opam packages"

--- a/opam-health-check.opam
+++ b/opam-health-check.opam
@@ -32,5 +32,6 @@ depends: [
   "uri"
   "tls" {>= "0.12.0"} # activate conduit with TLS for slack webhooks
   "conf-libev" # Required for lwt to avoid hitting the limits of select(2)
+  "conf-pixz" # TODO: Make it a library
 ]
 synopsis: "A toolchain to check for broken opam packages"

--- a/opam-health-check.opam
+++ b/opam-health-check.opam
@@ -27,7 +27,6 @@ depends: [
   "github-unix"
   "capnp-rpc-lwt"
   "capnp-rpc-unix"
-  "lz4"
   "lwt"
   "uri"
   "tls" {>= "0.12.0"} # activate conduit with TLS for slack webhooks

--- a/server/backend/backend.ml
+++ b/server/backend/backend.ml
@@ -10,13 +10,11 @@ let get_compilers logdir =
 
 module Pkg_tbl = Hashtbl.Make (String)
 
-let pkg_update ~conf ~old ~pool pkg_tbl logdir comp state pkg =
+let pkg_update ~pool pkg_tbl logdir comp state pkg =
   let get_content () = Lwt_pool.use pool begin fun () ->
     Server_workdirs.logdir_get_content ~comp ~state ~pkg logdir
   end in
-  let content =
-    if old || not (Server_configfile.enable_in_memory_logs conf) then Intf.Log.unstored get_content else Intf.Log.compressed (get_content ())
-  in
+  let content = Intf.Log.create get_content in
   let instances =
     match Pkg_tbl.find_opt pkg_tbl pkg with
     | Some instances -> Intf.Instance.create comp state content :: instances
@@ -24,17 +22,17 @@ let pkg_update ~conf ~old ~pool pkg_tbl logdir comp state pkg =
   in
   Pkg_tbl.replace pkg_tbl pkg instances
 
-let fill_pkgs_from_dir ~conf ~old ~pool pkg_tbl logdir comp =
+let fill_pkgs_from_dir ~pool pkg_tbl logdir comp =
   Server_workdirs.goodfiles ~switch:comp logdir >>= fun good_files ->
   Server_workdirs.partialfiles ~switch:comp logdir >>= fun partial_files ->
   Server_workdirs.badfiles ~switch:comp logdir >>= fun bad_files ->
   Server_workdirs.notavailablefiles ~switch:comp logdir >>= fun notavailable_files ->
   Server_workdirs.internalfailurefiles ~switch:comp logdir >|= fun internalfailure_files ->
-  List.iter (pkg_update ~conf ~old ~pool pkg_tbl logdir comp Intf.State.Good) good_files;
-  List.iter (pkg_update ~conf ~old ~pool pkg_tbl logdir comp Intf.State.Partial) partial_files;
-  List.iter (pkg_update ~conf ~old ~pool pkg_tbl logdir comp Intf.State.Bad) bad_files;
-  List.iter (pkg_update ~conf ~old ~pool pkg_tbl logdir comp Intf.State.NotAvailable) notavailable_files;
-  List.iter (pkg_update ~conf ~old ~pool pkg_tbl logdir comp Intf.State.InternalFailure) internalfailure_files
+  List.iter (pkg_update ~pool pkg_tbl logdir comp Intf.State.Good) good_files;
+  List.iter (pkg_update ~pool pkg_tbl logdir comp Intf.State.Partial) partial_files;
+  List.iter (pkg_update ~pool pkg_tbl logdir comp Intf.State.Bad) bad_files;
+  List.iter (pkg_update ~pool pkg_tbl logdir comp Intf.State.NotAvailable) notavailable_files;
+  List.iter (pkg_update ~pool pkg_tbl logdir comp Intf.State.InternalFailure) internalfailure_files
 
 let add_pkg full_name instances acc =
   let pkg = Intf.Pkg.name (Intf.Pkg.create ~full_name ~instances:[] ~maintainers:[] ~revdeps:0) in (* TODO: Remove this horror *)
@@ -43,9 +41,9 @@ let add_pkg full_name instances acc =
   Oca_server.Cache.get_revdeps cache full_name >|= fun revdeps ->
   Intf.Pkg.create ~full_name ~instances ~maintainers ~revdeps :: acc
 
-let get_pkgs ~conf ~pool ~old ~compilers logdir =
+let get_pkgs ~pool ~compilers logdir =
   let pkg_tbl = Pkg_tbl.create 10_000 in
-  Lwt_list.iter_s (fill_pkgs_from_dir ~conf ~old ~pool pkg_tbl logdir) compilers >>= fun () ->
+  Lwt_list.iter_s (fill_pkgs_from_dir ~pool pkg_tbl logdir) compilers >>= fun () ->
   Pkg_tbl.fold add_pkg pkg_tbl Lwt.return_nil >|=
   List.sort Intf.Pkg.compare
 
@@ -89,11 +87,11 @@ let tcp_server port callback =
     ~mode:(`TCP (`Port port))
     (Cohttp_lwt_unix.Server.make ~callback ())
 
-let cache_clear_and_init conf workdir =
+let cache_clear_and_init workdir =
   let pool = Lwt_pool.create 64 (fun () -> Lwt.return_unit) in
   Oca_server.Cache.clear_and_init
     cache
-    ~pkgs:(fun ~old ~compilers logdir -> get_pkgs ~conf ~pool ~old ~compilers logdir)
+    ~pkgs:(fun ~compilers logdir -> get_pkgs ~pool ~compilers logdir)
     ~compilers:(fun logdir -> get_compilers logdir)
     ~logdirs:(fun () -> Server_workdirs.logdirs workdir)
     ~maintainers:(fun () -> get_maintainers workdir)
@@ -123,10 +121,10 @@ let run_action_loop ~conf ~run_trigger f =
 
 let start conf workdir =
   let port = Server_configfile.admin_port conf in
-  let on_finished = cache_clear_and_init conf in
+  let on_finished = cache_clear_and_init in
   let run_trigger = Lwt_mvar.create_empty () in
   let callback = Admin.callback ~on_finished ~conf ~run_trigger workdir in
-  cache_clear_and_init conf workdir;
+  cache_clear_and_init workdir;
   Mirage_crypto_rng_lwt.initialize ();
   Admin.create_admin_key workdir >|= fun () ->
   let task () =

--- a/server/backend/check.ml
+++ b/server/backend/check.ml
@@ -307,10 +307,12 @@ let get_commit_hash_extra_repos conf =
 let move_tmpdirs_to_final ~switches logdir workdir =
   let metadatadir = Server_workdirs.metadatadir workdir in
   let tmpmetadatadir = Server_workdirs.tmpmetadatadir logdir in
+  let tmplogdir = Server_workdirs.tmplogdir logdir in
   let switches = List.map Intf.Switch.name switches in
   Server_workdirs.logdir_compress ~switches logdir >>= fun () ->
   Oca_lib.rm_rf metadatadir >>= fun () ->
-  Lwt_unix.rename (Fpath.to_string tmpmetadatadir) (Fpath.to_string metadatadir)
+  Lwt_unix.rename (Fpath.to_string tmpmetadatadir) (Fpath.to_string metadatadir) >>= fun () ->
+  Oca_lib.rm_rf tmplogdir
 
 let run_jobs ~cap ~conf ~pool ~stderr logdir switches pkgs =
   let len_suffix = "/"^string_of_int (Pkg_set.cardinal pkgs * List.length switches) in

--- a/server/backend/check.ml
+++ b/server/backend/check.ml
@@ -398,11 +398,12 @@ let run ~on_finished ~conf cache workdir =
           let (_, jobs) = run_jobs ~cap ~conf ~pool ~stderr new_logdir switches pkgs in
           let (_, jobs) = get_metadata ~jobs ~cap ~conf ~pool ~stderr new_logdir switch pkgs in
           Lwt.join jobs >>= fun () ->
+          Oca_lib.timer_log timer stderr "Operation" >>= fun () ->
           Lwt_io.write_line stderr "Finishing up..." >>= fun () ->
           move_tmpdirs_to_final ~switches:switches' new_logdir workdir >>= fun () ->
           on_finished workdir;
           trigger_slack_webhooks ~stderr ~old_logdir ~new_logdir conf >>= fun () ->
-          Oca_lib.timer_log timer stderr "Operation"
+          Oca_lib.timer_log timer stderr "Clean up"
       | [] ->
           Lwt_io.write_line stderr "No switches."
       end

--- a/server/lib/cache.ml
+++ b/server/lib/cache.ml
@@ -96,13 +96,8 @@ let create () = {
   html_run_list = Lwt.return "";
 }
 
-let call_pkgs ~pkgs = function
-  | [] ->
-      Lwt.return_nil
-  | (logdir, compilers)::logdirs ->
-      let pkg = pkgs ~old:false ~compilers logdir in
-      let pkgs = List.map (fun (logdir, compilers) -> (logdir, pkgs ~old:true ~compilers logdir)) logdirs in
-      Lwt.return ((logdir, pkg) :: pkgs)
+let call_pkgs ~pkgs logdirs =
+  Lwt.return (List.map (fun (logdir, compilers) -> (logdir, pkgs ~compilers logdir)) logdirs)
 
 let call_generate_diff (new_logdir, new_pkgs) (old_logdir, old_pkgs) =
   let diff =

--- a/server/lib/cache.mli
+++ b/server/lib/cache.mli
@@ -7,7 +7,7 @@ val create : unit -> t
 
 val clear_and_init :
   t ->
-  pkgs:(old:bool -> compilers:Intf.Compiler.t list -> Server_workdirs.logdir -> Intf.Pkg.t list Lwt.t) ->
+  pkgs:(compilers:Intf.Compiler.t list -> Server_workdirs.logdir -> Intf.Pkg.t list Lwt.t) ->
   compilers:(Server_workdirs.logdir -> Intf.Compiler.t list Lwt.t) ->
   logdirs:(unit -> Server_workdirs.logdir list Lwt.t) ->
   maintainers:(unit -> string list Maintainers_cache.t Lwt.t) ->

--- a/server/lib/server.ml
+++ b/server/lib/server.ml
@@ -130,7 +130,8 @@ module Make (Backend : Backend_intf.S) = struct
       (Cohttp_lwt_unix.Server.make ~callback ())
 
   let main ~debug ~workdir =
-    let workdir = Server_workdirs.create ~workdir in
+    Lwt_unix.getcwd () >>= fun cwd ->
+    let workdir = Server_workdirs.create ~cwd ~workdir in
     Server_workdirs.init_base workdir >>= fun () ->
     let conf = Server_configfile.from_workdir workdir in
     let port = Server_configfile.port conf in


### PR DESCRIPTION
WIP experiment, code unfinished.

Potentially this would allow opam-health-check to:
* reduce its disk consumption by a factor of a 100 (e.g. for one run, from 7Go uncompressed to ~70Mo compressed)
* with negligible performance hit when reading a log file (the indexation allows to have almost no performance cost)
* and negligible performance hit when searching into log files (ideally same as above but more test is needed)

Will rely on https://github.com/vasi/pixz