### PR TITLE
Make opam-health-check platform-agnostic

### DIFF
--- a/lib/server_configfile.ml
+++ b/lib/server_configfile.ml
@@ -14,6 +14,9 @@ type t = {
   mutable with_test : bool option;
   mutable list_command : string option;
   mutable extra_command : string option;
+  mutable platform_os : string option;
+  mutable platform_arch : string option;
+  mutable platform_distribution : string option;
   mutable ocaml_switches : Intf.Switch.t list option;
   mutable slack_webhooks : Uri.t list option;
 }
@@ -32,6 +35,9 @@ let create_conf yamlfile = {
   with_test = None;
   list_command = None;
   extra_command = None;
+  platform_os = None;
+  platform_arch = None;
+  platform_distribution = None;
   ocaml_switches = None;
   slack_webhooks = None;
 }
@@ -95,6 +101,17 @@ let set_config conf = function
       set_field ~field (fun () -> conf.list_command <- Some list_command) conf.list_command
   | "extra-command" as field, `String extra_command ->
       set_field ~field (fun () -> conf.extra_command <- Some extra_command) conf.extra_command
+  | "platform", `O platform ->
+      List.iter (function
+        | "os" as field, `String os ->
+            set_field ~field (fun () -> conf.platform_os <- Some os) conf.platform_os
+        | "arch" as field, `String arch ->
+            set_field ~field (fun () -> conf.platform_arch <- Some arch) conf.platform_arch
+        | "distribution" as field, `String distribution ->
+            set_field ~field (fun () -> conf.platform_distribution <- Some distribution) conf.platform_distribution
+        | field, _ ->
+            failwith (Printf.sprintf "Config parser: '%s' field not recognized" field)
+      ) platform
   | "ocaml-switches" as field, `A switches ->
       let switches = List.map get_comp switches in
       set_field ~field (fun () -> conf.ocaml_switches <- Some switches) conf.ocaml_switches
@@ -164,6 +181,12 @@ let set_defaults conf =
     conf.with_test <- Some false; (* TODO: Enable by default in the future (takes 1.5x the time) *)
   if Option.is_none conf.list_command then
     conf.list_command <- Some Oca_lib.default_list_command;
+  if Option.is_none conf.platform_os then
+    conf.platform_os <- Some "linux";
+  if Option.is_none conf.platform_arch then
+    conf.platform_arch <- Some "x86_64";
+  if Option.is_none conf.platform_distribution then
+    conf.platform_distribution <- Some "debian-unstable";
   if Option.is_none conf.slack_webhooks then
     conf.slack_webhooks <- Some [];
   let yaml = Result.get_exn (Yaml.to_string (yaml_of_conf conf)) in
@@ -231,5 +254,8 @@ let extra_repositories {extra_repositories; _} = Option.get_exn extra_repositori
 let with_test {with_test; _} = Option.get_exn with_test
 let list_command {list_command; _} = Option.get_exn list_command
 let extra_command {extra_command; _} = extra_command
+let platform_os {platform_os; _} = Option.get_exn platform_os
+let platform_arch {platform_arch; _} = Option.get_exn platform_arch
+let platform_distribution {platform_distribution; _} = Option.get_exn platform_distribution
 let ocaml_switches {ocaml_switches; _} = ocaml_switches
 let slack_webhooks {slack_webhooks; _} = Option.get_exn slack_webhooks

--- a/lib/server_configfile.ml
+++ b/lib/server_configfile.ml
@@ -154,6 +154,11 @@ let yaml_of_conf conf =
     "with-test", `Bool (Option.get_exn conf.with_test);
     "list-command", `String (Option.get_exn conf.list_command);
     "extra-command", Option.map_or ~default:`Null (fun s -> `String s) conf.extra_command;
+    "platform", `O [
+      "os", `String (Option.get_exn conf.platform_os);
+      "arch", `String (Option.get_exn conf.platform_arch);
+      "distribution", `String (Option.get_exn conf.platform_distribution);
+    ];
     "ocaml-switches", Option.map_or ~default:`Null yaml_of_ocaml_switches conf.ocaml_switches;
     "slack-webhooks", Option.map_or ~default:`Null yaml_of_slack_webhooks conf.slack_webhooks;
   ]

--- a/lib/server_configfile.mli
+++ b/lib/server_configfile.mli
@@ -14,6 +14,9 @@ val extra_repositories : t -> Intf.Repository.t list
 val with_test : t -> bool
 val list_command : t -> string
 val extra_command : t -> string option
+val platform_os : t -> string
+val platform_arch : t -> string
+val platform_distribution : t -> string
 val ocaml_switches : t -> Intf.Switch.t list option
 val slack_webhooks : t -> Uri.t list
 

--- a/server/backend/check.ml
+++ b/server/backend/check.ml
@@ -187,7 +187,7 @@ let get_obuilder ~conf ~opam_commit ~opam_repo_commit ~extra_repos switch =
   in
   stage ~from begin
     [ user ~uid:1000 ~gid:1000;
-      run ~cache ~network {|
+      run ~network {|
         set -e
         git clone git://github.com/kit-ty-kate/opam.git /tmp/opam
         git -C /tmp/opam checkout %s

--- a/server/backend/check.ml
+++ b/server/backend/check.ml
@@ -191,7 +191,7 @@ let get_obuilder ~conf ~opam_commit ~opam_repo_commit ~extra_repos switch =
         set -e
         git clone git://github.com/kit-ty-kate/opam.git /tmp/opam
         git -C /tmp/opam checkout %s
-        opam pin add -yn ocamlfind git://github.com/kit-ty-kate/ocamlfind.git
+        opam pin add -yn ocamlfind git://github.com/kit-ty-kate/ocamlfind.git#no-m4
         opam pin add -yn /tmp/opam
         opam install -y opam-devel opam-0install-cudf
         sudo mv "$(opam var opam-devel:lib)/opam" /usr/bin/opam

--- a/server/backend/check.ml
+++ b/server/backend/check.ml
@@ -219,7 +219,7 @@ let get_obuilder ~conf ~opam_commit ~opam_repo_commit ~extra_repos switch =
       List.map (fun (repo, hash) ->
         let name = Filename.quote (Intf.Repository.name repo) in
         let github = Intf.Repository.github repo in
-        [ run ~network "git clone 'git://github.com/%s.git' %s && git -C ~/%s checkout %s" github name name hash;
+        [ run ~network "git clone 'git://github.com/%s.git' ~/%s && git -C ~/%s checkout %s" github name name hash;
           run "opam repository add --dont-select %s ~/%s" name name;
         ]
       ) extra_repos

--- a/server/lib/cache.ml
+++ b/server/lib/cache.ml
@@ -155,10 +155,6 @@ let get_revdeps self k =
   self.revdeps >|= fun revdeps ->
   Option.get_or ~default:(-1) (Revdeps_cache.find_opt revdeps k)
 
-let call_html_diff ~html_diff ((old_logdir, old_pkgs), (new_logdir, new_pkgs)) =
-  let html_diff = generate_diff old_pkgs new_pkgs |> html_diff ~old_logdir ~new_logdir in
-  ((old_logdir, new_logdir), html_diff)
-
 let get_html_diff ~old_logdir ~new_logdir self =
   get_pkgs ~logdir:old_logdir self >>= fun old_pkgs ->
   get_pkgs ~logdir:new_logdir self >|= fun new_pkgs ->


### PR DESCRIPTION
This change does several things:
* Make the platform being checked configurable, by adding the `platform.os`, `platform.arch` and `platform.distribution` to the configuration file.
* rearrange the build script so that:
  - the only directories used are `/tmp` and `~/` (aka. `$HOME`) and no fixed path to `/home/opam` anymore.
  - removing the m4 dependency from `ocamlfind` (https://github.com/ocaml/ocamlfind/pull/13) so that no depext needs to be installed and removed (the later part is not being dealt with in opam depext)

Currently there are still a few observations:
- it seems to be relatively easy to have platform-agnostic (UNIX..) code. The only non-platform-agnostic code so far is the bit that prefixes the base image name by `ocurrent/opam:` on linux. If the macOS workers could discard this, we would have no platform specific code and it would be **a lot** easier to use macOS in `opam-repo-ci` and `ocaml-ci`.
- A few things are done in `docker-base-images` directly (e.g. `opam install ocaml-secondary-compiler` on OCaml < 4.08). I think it would be nice to be as close as possible to what `docker-base-images` does. I think it should be relatively easy to add those things to the setup step.

This work was done mainly with @patricoferris's work on the macOS worker in mind.
In theory this should accommodate any UNIX-like workers in the future (BSDs, …)
I'm not sure how this can scale to Windows though (cc @dra27)