### PR TITLE
Make the revdeps counter more accurate of actual (recent) use

### DIFF
--- a/opam-health-check.opam
+++ b/opam-health-check.opam
@@ -16,6 +16,7 @@ depends: [
   "cohttp-lwt"
   "cohttp-lwt-unix"
   "containers" {>= "3.4"}
+  "ocaml-version"
   "opam-core"
   "opam-format"
   "mirage-crypto-pk" {>= "0.7.0"}

--- a/server/backend/check.ml
+++ b/server/backend/check.ml
@@ -297,8 +297,9 @@ module Pkg_set = Set.Make (String)
 
 let revdeps_script pkg =
   let pkg = Filename.quote pkg in
-  {|opam list --color=never -s --recursive --depopts --depends-on |}^pkg^{| && \
-    opam list --color=never -s --with-test --with-doc --depopts --depends-on |}^pkg
+  let latest_ocaml = Ocaml_version.to_string Ocaml_version.Releases.latest in
+  {|opam list --color=never -s --recursive --depopts --depends-on |}^pkg^{| --coinstallable-with ocaml.|}^latest_ocaml^{| && \
+    opam list --color=never -s --with-test --with-doc --depopts --depends-on |}^pkg^{| --coinstallable-with ocaml.|}^latest_ocaml
 
 let get_metadata ~debug ~jobs ~cap ~conf ~pool ~stderr logdir (_, base_obuilder) pkgs =
   let get_revdeps ~base_obuilder ~pkgname ~pkg ~logdir =

--- a/server/backend/dune
+++ b/server/backend/dune
@@ -16,6 +16,7 @@
     containers
     oca_server
     opam-core
+    ocaml-version
     opam-format
     obuilder-spec
     ocluster-api


### PR DESCRIPTION
This tries to make the revdeps counter a bit more accurate. For example, currently `camlp4` is still at the top of the page with 2111 revdeps. However this is not true for recent versions of the compiler (only 70 in this example).

This proposal makes it so that the counter is now valid for recent uses.

There are a few caviats to that:
- this is slower (2 to 3 times)
- this is even slower on opam 2.1
- this is less accurate if what the user care about is older version of the compiler