### PR TITLE
Improve the user experience when encountering an error

### DIFF
--- a/server/lib/server.mli
+++ b/server/lib/server.mli
@@ -1,5 +1,3 @@
-[@@@ocaml.warning "-67"] (* TODO: remove (requires OCaml >= 4.08) *)
-
-module Make (Backend : Backend_intf.S) : sig
+module Make (_ : Backend_intf.S) : sig
   val main : debug:bool -> cap_file:string -> workdir:string -> unit Lwt.t
 end


### PR DESCRIPTION
This prompt the users opam-health-check to use the client command to check failures instead of expecting the server to print the debug logs using --debug