### PR TITLE
Replace ocaml-xdg-basedir with directories

### DIFF
--- a/client/client.ml
+++ b/client/client.ml
@@ -213,9 +213,13 @@ let log_cmd ~confdir ~conffile =
   (term, info)
 
 let cmds =
-  let confdir = XDGBaseDir.(default.config_home) in
-  let confdir = Fpath.v confdir in
-  let confdir = Fpath.add_seg confdir "opam-health-check" in
+  let module App_id = struct
+      let qualifier = "org"
+      let organization = "ocurrent"
+      let application = "opam-health-check"
+    end in
+  let module M = Directories.Project_dirs(App_id) in
+  let confdir = M.config_dir |> Option.get_exn_or "Couldn't derive config_dir" |> Fpath.v in
   let conffile = Fpath.add_seg confdir "config.yaml" in
   [
     init_cmd ~confdir ~conffile; (* TODO: Handle profilename on init *)

--- a/client/dune
+++ b/client/dune
@@ -8,7 +8,7 @@
     cohttp-lwt
     cohttp-lwt-unix
     containers
-    xdg-basedir
+    directories
     fpath
     uri
     lwt

--- a/opam-health-check.opam
+++ b/opam-health-check.opam
@@ -16,6 +16,7 @@ depends: [
   "cohttp-lwt"
   "cohttp-lwt-unix"
   "containers" {>= "3.4"}
+  "directories"
   "opam-core"
   "opam-format"
   "mirage-crypto-pk" {>= "0.7.0"}
@@ -27,7 +28,6 @@ depends: [
   "yaml" {>= "2.0.0"}
   "sexplib" {>= "v0.9.0"}
   "sexplib0" {>= "v0.9.0"}
-  "ocaml-xdg-basedir"
   "obuilder-spec" {>= "0.2"}
   "ocluster-api" {>= "0.1"}
   "current_ansi" {>= "0.1"}


### PR DESCRIPTION
I reported <https://github.com/gildor478/ocaml-xdg-basedir/pull/4> some time ago on ocaml-xdg-basedir. The library doesn't seem to be maintained anymore, and @zapashcanon suggested [ocamlpro/directories](https://github.com/ocamlpro/directories), which is more recent and has better support for Windows and macOS.