### PR TITLE
More lwt ppx

### DIFF
--- a/client/client.ml
+++ b/client/client.ml
@@ -16,7 +16,7 @@ let rec encrypt_msg ~key msg =
 
 let print_body body =
   let stream = Cohttp_lwt.Body.to_stream body in
-  let%lwt () = Lwt_stream.iter (fun s -> print_string s; flush stdout) stream in
+  Lwt_stream.iter (fun s -> print_string s; flush stdout) stream;%lwt
   Lwt.return (print_newline ())
 
 let process_response (res, body) =
@@ -24,7 +24,7 @@ let process_response (res, body) =
   | `OK ->
       print_body body
   | `Upgrade_required ->
-      let%lwt () = print_body body in
+      print_body body;%lwt
       raise Exit
   | _ ->
       print_endline "A problem occured";

--- a/lib/oca_lib.ml
+++ b/lib/oca_lib.ml
@@ -124,7 +124,7 @@ let mkdir_p dir =
 
 let rec rm_rf dirname =
   let%lwt dir = Lwt_unix.opendir (Fpath.to_string dirname) in
-  Lwt.finalize begin fun () ->
+  begin
     let rec rm_files () =
       match%lwt Lwt_unix.readdir dir with
       | "." | ".." -> rm_files ()
@@ -139,10 +139,11 @@ let rec rm_rf dirname =
           rm_files ()
     in
     try%lwt rm_files () with End_of_file -> Lwt.return_unit
-  end begin fun () ->
+  end
+  [%lwt.finally
     Lwt_unix.closedir dir;%lwt
     Lwt_unix.rmdir (Fpath.to_string dirname)
-  end
+  ]
 
 type timer = float ref
 

--- a/lib/server_workdirs.ml
+++ b/lib/server_workdirs.ml
@@ -116,7 +116,7 @@ let logdir_move ~switches (Logdir (ty, _, _, workdir, _) as logdir) = match ty w
       let cwd = tmplogdir logdir in
       let directories = List.map Intf.Compiler.to_string switches in
       let archive = base_logdir workdir/get_logdir_name logdir+"txz" in
-      let%lwt () = Oca_lib.compress_tpxz_archive ~cwd ~directories archive in
+      Oca_lib.compress_tpxz_archive ~cwd ~directories archive;%lwt
       Oca_lib.rm_rf cwd
   | Uncompressed ->
       let tmplogdir = tmplogdir logdir in
@@ -154,23 +154,23 @@ let tmprevdepsfile ~pkg logdir = tmprevdepsdir logdir/pkg
 let configfile workdir = workdir/"config.yaml"
 
 let init_base workdir =
-  let%lwt () = Oca_lib.mkdir_p (keysdir workdir) in
-  let%lwt () = Oca_lib.mkdir_p (base_logdir workdir) in
-  let%lwt () = Oca_lib.mkdir_p (ilogdir workdir) in
-  let%lwt () = Oca_lib.mkdir_p (opamsdir workdir) in
+  Oca_lib.mkdir_p (keysdir workdir);%lwt
+  Oca_lib.mkdir_p (base_logdir workdir);%lwt
+  Oca_lib.mkdir_p (ilogdir workdir);%lwt
+  Oca_lib.mkdir_p (opamsdir workdir);%lwt
   Oca_lib.mkdir_p (revdepsdir workdir)
 
 let init_base_job ~switch logdir =
   let switch = Intf.Switch.name switch in
-  let%lwt () = Oca_lib.mkdir_p (tmpgooddir ~switch logdir) in
-  let%lwt () = Oca_lib.mkdir_p (tmppartialdir ~switch logdir) in
-  let%lwt () = Oca_lib.mkdir_p (tmpbaddir ~switch logdir) in
-  let%lwt () = Oca_lib.mkdir_p (tmpnotavailabledir ~switch logdir) in
+  Oca_lib.mkdir_p (tmpgooddir ~switch logdir);%lwt
+  Oca_lib.mkdir_p (tmppartialdir ~switch logdir);%lwt
+  Oca_lib.mkdir_p (tmpbaddir ~switch logdir);%lwt
+  Oca_lib.mkdir_p (tmpnotavailabledir ~switch logdir);%lwt
   Oca_lib.mkdir_p (tmpinternalfailuredir ~switch logdir)
 
 let init_base_jobs ~switches logdir =
-  let%lwt () = Oca_lib.mkdir_p (tmplogdir logdir) in
-  let%lwt () = Oca_lib.mkdir_p (tmpmetadatadir logdir) in
-  let%lwt () = Oca_lib.mkdir_p (tmprevdepsdir logdir) in
-  let%lwt () = Oca_lib.mkdir_p (tmpopamsdir logdir) in
+  Oca_lib.mkdir_p (tmplogdir logdir);%lwt
+  Oca_lib.mkdir_p (tmpmetadatadir logdir);%lwt
+  Oca_lib.mkdir_p (tmprevdepsdir logdir);%lwt
+  Oca_lib.mkdir_p (tmpopamsdir logdir);%lwt
   Lwt_list.iter_s (fun switch -> init_base_job ~switch logdir) switches

--- a/server/backend/admin.ml
+++ b/server/backend/admin.ml
@@ -53,7 +53,7 @@ let get_log workdir =
       Lwt.return (Some (Bytes.to_string buf))
     end else if is_running then begin
       off := new_off;
-      let%lwt () = Lwt_unix.sleep 1. in
+      Lwt_unix.sleep 1.;%lwt
       loop ()
     end else
       Lwt.return_none
@@ -64,46 +64,46 @@ let admin_action ~on_finished ~conf ~run_trigger workdir body =
   let%lwt resp =
     match String.split_on_char '\n' body with
     | ["set-auto-run-interval"; i] ->
-        let%lwt () = Server_configfile.set_auto_run_interval conf (int_of_string i) in
+        Server_configfile.set_auto_run_interval conf (int_of_string i);%lwt
         Lwt.return (fun () -> Lwt.return_none)
     | ["set-processes"; i] ->
         let i = int_of_string i in
         if i < 0 then
           failwith "Cannot set the number of processes to a negative value."
         else
-          let%lwt () = Server_configfile.set_processes conf i in
+          Server_configfile.set_processes conf i;%lwt
           Lwt.return (fun () -> Lwt.return_none)
     | ["add-ocaml-switch";name;switch] ->
         let switch = Intf.Switch.create ~name ~switch in
         let switches = switch :: Option.get_or ~default:[] (Server_configfile.ocaml_switches conf) in
         let switches = List.sort Intf.Switch.compare switches in
-        let%lwt () = Server_configfile.set_ocaml_switches conf switches in
+        Server_configfile.set_ocaml_switches conf switches;%lwt
         Lwt.return (fun () -> Lwt.return_none)
     | ["set-ocaml-switch";name;switch] ->
         let switch = Intf.Switch.create ~name ~switch in
         let switches = Option.get_or ~default:[] (Server_configfile.ocaml_switches conf) in
         let idx, _ = Option.get_exn_or "can't find switch name" (List.find_idx (Intf.Switch.equal switch) switches) in
         let switches = List.set_at_idx idx switch switches in
-        let%lwt () = Server_configfile.set_ocaml_switches conf switches in
+        Server_configfile.set_ocaml_switches conf switches;%lwt
         Lwt.return (fun () -> Lwt.return_none)
     | ["rm-ocaml-switch";name] ->
         let switch = Intf.Switch.create ~name ~switch:"(* TODO: remove this shit *)" in
         let switches = Option.get_or ~default:[] (Server_configfile.ocaml_switches conf) in
         let switches = List.remove ~eq:Intf.Switch.equal ~key:switch switches in
-        let%lwt () = Server_configfile.set_ocaml_switches conf switches in
+        Server_configfile.set_ocaml_switches conf switches;%lwt
         Lwt.return (fun () -> Lwt.return_none)
     | "set-slack-webhooks"::webhooks ->
         let webhooks = List.map Uri.of_string webhooks in
-        let%lwt () = Server_configfile.set_slack_webhooks conf webhooks in
+        Server_configfile.set_slack_webhooks conf webhooks;%lwt
         Lwt.return (fun () -> Lwt.return_none)
     | ["set-list-command";cmd] ->
-        let%lwt () = Server_configfile.set_list_command conf cmd in
+        Server_configfile.set_list_command conf cmd;%lwt
         Lwt.return (fun () -> Lwt.return_none)
     | ["run"] ->
-        let%lwt () = Lwt_mvar.put run_trigger () in
+        Lwt_mvar.put run_trigger ();%lwt
         Lwt.return (fun () -> Lwt.return_none)
     | ["add-user";username] ->
-        let%lwt () = create_userkey workdir username in
+        create_userkey workdir username;%lwt
         Lwt.return (fun () -> Lwt.return_none)
     | ["clear-cache"] ->
         on_finished workdir;

--- a/server/backend/check.ml
+++ b/server/backend/check.ml
@@ -75,11 +75,7 @@ let ocluster_build ~cap ~conf ~base_obuilder ~stdout ~stderr c =
 
 let exec_out ~fexec ~fout =
   let stdin, stdout = Lwt_io.pipe () in
-  let proc =
-    Lwt.finalize
-      (fun () -> fexec ~stdout)
-      (fun () -> Lwt_io.close stdout)
-  in
+  let proc = (fexec ~stdout) [%lwt.finally Lwt_io.close stdout] in
   let%lwt res = fout ~stdin in
   Lwt_io.close stdin;%lwt
   let%lwt r = proc in

--- a/server/lib/server.ml
+++ b/server/lib/server.ml
@@ -77,7 +77,7 @@ module Make (Backend : Backend_intf.S) = struct
     Lwt.return
 
   let callback ~conf backend _conn req body_NOT_USED =
-    let%lwt () = Cohttp_lwt.Body.drain_body body_NOT_USED in
+    Cohttp_lwt.Body.drain_body body_NOT_USED;%lwt
     let uri = Cohttp.Request.uri req in
     let get_log ~logdir ~comp ~state ~pkg =
       let%lwt logdir = get_logdir logdir in
@@ -132,7 +132,7 @@ module Make (Backend : Backend_intf.S) = struct
     Printexc.record_backtrace debug;
     let%lwt cwd = Lwt_unix.getcwd () in
     let workdir = Server_workdirs.create ~cwd ~workdir in
-    let%lwt () = Server_workdirs.init_base workdir in
+    Server_workdirs.init_base workdir;%lwt
     let conf = Server_configfile.from_workdir workdir in
     let port = Server_configfile.port conf in
     let%lwt (backend, backend_task) = Backend.start ~debug ~cap_file conf workdir in


### PR DESCRIPTION
I saw you've switched to lwt_ppx, and noticed we could use the sequence syntax for `unit Lwt.t` expressions (that's just syntax sugar) but also `[%lwt.finally]` instead of `Lwt.finally` that also preserves exceptions.