### PR TITLE
Fix "TLS failure: End_of_file" when calling the webhooks

### DIFF
--- a/opam-health-check.opam
+++ b/opam-health-check.opam
@@ -15,6 +15,7 @@ depends: [
   "cohttp"
   "cohttp-lwt"
   "cohttp-lwt-unix"
+  "http-lwt-client"
   "containers" {>= "3.4"}
   "opam-core"
   "opam-format"

--- a/opam-health-check.opam
+++ b/opam-health-check.opam
@@ -48,4 +48,8 @@ depends: [
   "conf-pixz" # TODO: Make it a library
   # TODO: Add conf-ugrep
 ]
+conflicts: [
+  "dns-client-lwt" {< "6.1.4"} # Required to fix https://github.com/roburio/http-lwt-client/issues/8
+  "happy-eyeballs-lwt" {< "0.1.3"} # Required to fix https://github.com/roburio/http-lwt-client/issues/8
+]
 synopsis: "A toolchain to check for broken opam packages"

--- a/server/backend/check.ml
+++ b/server/backend/check.ml
@@ -404,6 +404,7 @@ let trigger_slack_webhooks ~stderr ~old_logdir ~new_logdir conf =
     let%lwt () = Lwt_io.write_line stderr ("Triggering Slack webhook "^Uri.to_string webhook) in
     match%lwt
       Http_lwt_client.one_request
+        ~config:(`HTTP_1_1 Httpaf.Config.default) (* TODO: Remove this when https://github.com/roburio/http-lwt-client/issues/7 is fixed *)
         ~meth:`POST
         ~headers:[("Content-type", "application/json")]
         ~body

--- a/server/backend/check.ml
+++ b/server/backend/check.ml
@@ -410,7 +410,11 @@ let trigger_slack_webhooks ~stderr ~old_logdir ~new_logdir conf =
         (Uri.to_string webhook)
     with
     | Ok ({Http_lwt_client.status = `OK; _}, _body) -> Lwt.return_unit
-    | Ok _ | Error _ -> Lwt_io.write_line stderr ("Something when wrong with slack webhook "^Uri.to_string webhook)
+    | Ok (resp, body) ->
+        let resp = Format.sprintf "%a" Http_lwt_client.pp_response resp in
+        let body = match body with None -> "" | Some body -> "\nBody: "^body in
+        Lwt_io.write_line stderr ("Webhook returned failure: "^resp^body)
+    | Error (`Msg msg) -> Lwt_io.write_line stderr ("Webhook failed with: "^msg)
   end
 
 let get_cap ~stderr ~cap_file =

--- a/server/backend/dune
+++ b/server/backend/dune
@@ -12,6 +12,7 @@
     cohttp-lwt
     cohttp-lwt-unix
     docker_hub
+    http-lwt-client
     sexplib
     sexplib0
     cstruct


### PR DESCRIPTION
Existed in both `Cohttp_lwt_unix.Client` and `Http_lwt_client` but got fixed only in the latter so I’m switching to it.