### PR TITLE
Improve and avoid race condition with the cache

### DIFF
--- a/server/backend/admin.ml
+++ b/server/backend/admin.ml
@@ -106,7 +106,7 @@ let admin_action ~on_finished ~conf ~run_trigger workdir body =
         let%lwt () = create_userkey workdir username in
         Lwt.return (fun () -> Lwt.return_none)
     | ["clear-cache"] ->
-        on_finished workdir;
+        let%lwt () = on_finished workdir in
         Lwt.return (fun () -> Lwt.return_none)
     | ["log"] ->
         get_log workdir

--- a/server/backend/admin.mli
+++ b/server/backend/admin.mli
@@ -1,7 +1,7 @@
 val create_admin_key : Server_workdirs.t -> unit Lwt.t
 
 val callback :
-  on_finished:(Server_workdirs.t -> unit) ->
+  on_finished:(Server_workdirs.t -> unit Lwt.t) ->
   conf:Server_configfile.t ->
   run_trigger:unit Lwt_mvar.t ->
   Server_workdirs.t ->

--- a/server/backend/backend.ml
+++ b/server/backend/backend.ml
@@ -136,7 +136,7 @@ let start ~debug ~cap_file conf workdir =
   let on_finished = cache_clear_and_init in
   let run_trigger = Lwt_mvar.create_empty () in
   let callback = Admin.callback ~on_finished ~conf ~run_trigger workdir in
-  cache_clear_and_init workdir;
+  Lwt.ignore_result (cache_clear_and_init workdir);
   Mirage_crypto_rng_lwt.initialize ();
   let%lwt () = Admin.create_admin_key workdir in
   let task () =

--- a/server/backend/check.ml
+++ b/server/backend/check.ml
@@ -512,7 +512,7 @@ let run ~debug ~cap_file ~on_finished ~conf cache workdir =
             let%lwt () = Oca_lib.timer_log timer stderr "Operation" in
             let%lwt () = Lwt_io.write_line stderr "Finishing up..." in
             let%lwt () = move_tmpdirs_to_final ~switches:switches' new_logdir workdir in
-            on_finished workdir;
+            let%lwt () = on_finished workdir in
             let%lwt () = trigger_slack_webhooks ~stderr ~old_logdir ~new_logdir conf in
             Oca_lib.timer_log timer stderr "Clean up"
         | [] ->

--- a/server/backend/check.mli
+++ b/server/backend/check.mli
@@ -1,7 +1,7 @@
 val run :
   debug:bool ->
   cap_file:string ->
-  on_finished:(Server_workdirs.t -> unit) ->
+  on_finished:(Server_workdirs.t -> unit Lwt.t) ->
   conf:Server_configfile.t ->
   Oca_server.Cache.t ->
   Server_workdirs.t ->

--- a/server/lib/cache.ml
+++ b/server/lib/cache.ml
@@ -105,7 +105,14 @@ let clear_and_init self ~pkgs ~compilers ~logdirs ~opams ~revdeps =
     ) compilers |>
     Lwt.return
   end;
-  Html_cache.clear self.html_tbl
+  Html_cache.clear self.html_tbl;
+  Lwt.join [
+    (let%lwt _ = self.opams in Lwt.return_unit);
+    (let%lwt _ = self.revdeps in Lwt.return_unit);
+    (let%lwt _ = self.logdirs in Lwt.return_unit);
+    (let%lwt _ = self.compilers in Lwt.return_unit);
+    (let%lwt _ = self.pkgs in Lwt.return_unit);
+  ]
 
 let is_deprecated flag =
   String.equal (OpamTypesBase.string_of_pkg_flag flag) "deprecated"

--- a/server/lib/cache.mli
+++ b/server/lib/cache.mli
@@ -12,7 +12,7 @@ val clear_and_init :
   logdirs:(unit -> Server_workdirs.logdir list Lwt.t) ->
   opams:(unit -> OpamFile.OPAM.t Opams_cache.t Lwt.t) ->
   revdeps:(unit -> int Revdeps_cache.t Lwt.t) ->
-  unit
+  unit Lwt.t
 
 val get_latest_logdir : t -> Server_workdirs.logdir option Lwt.t
 val get_html : conf:Server_configfile.t -> t -> Html.query -> Server_workdirs.logdir -> string Lwt.t


### PR DESCRIPTION
Waiting for all the action to finish when refreshing the cache is a much sainer behaviour and avoids issues (race-conditions) and slow downs for people who go to the website while the cache is being refreshed