### PR TITLE
Fix OOM kill

### DIFF
--- a/lib/server_workdirs.ml
+++ b/lib/server_workdirs.ml
@@ -16,7 +16,7 @@ let keyfile ~username workdir = keysdir workdir/username+"key"
 type logdir_files = string list
 
 type logdir_ty = Uncompressed | Compressed
-type logdir = Logdir of (logdir_ty * float * string * t * logdir_files Lwt.t Lazy.t)
+type logdir = Logdir of (logdir_ty * float * string * t * logdir_files)
 (* TODO: differenciate logdir and tmplogdir *)
 
 let base_logdir workdir = workdir/"logs"
@@ -24,24 +24,27 @@ let base_tmpdir workdir = workdir/"tmp"
 
 let new_logdir ~compressed ~hash ~start_time workdir =
   let ty = if compressed then Compressed else Uncompressed in
-  Logdir (ty, start_time, hash, workdir, lazy (Lwt.return []))
+  Logdir (ty, start_time, hash, workdir, [])
 
 let logdirs workdir =
   let base_logdir = base_logdir workdir in
   let%lwt dirs = Oca_lib.get_files base_logdir in
   let dirs = List.sort (fun x y -> -String.compare x y) dirs in
-  List.map (fun dir ->
+  Lwt_list.map_s (fun dir ->
     match String.split_on_char '-' dir with
     | [time; hash] ->
         let logdir = base_logdir/dir in
         begin match String.split_on_char '.' hash with
-        | [hash] -> Logdir (Uncompressed, float_of_string time, hash, workdir, lazy (Oca_lib.scan_dir logdir))
-        | [hash; "txz"] -> Logdir (Compressed, float_of_string time, hash, workdir, lazy (Oca_lib.scan_tpxz_archive logdir))
+        | [hash] ->
+            let%lwt files = Oca_lib.scan_dir logdir in
+            Lwt.return (Logdir (Uncompressed, float_of_string time, hash, workdir, files))
+        | [hash; "txz"] ->
+            let%lwt files = Oca_lib.scan_tpxz_archive logdir in
+            Lwt.return (Logdir (Compressed, float_of_string time, hash, workdir, files))
         | _ -> assert false
         end
     | _ -> assert false
-  ) dirs |>
-  Lwt.return
+  ) dirs
 
 let logdir_ty_equal ty1 ty2 = match ty1, ty2 with
   | Uncompressed, Uncompressed
@@ -61,14 +64,12 @@ let get_logdir_time (Logdir (_, time, _, _, _)) = time
 
 let get_files ~name ~switch (Logdir (_, _, _, _, files)) =
   let switch = Intf.Compiler.to_string switch in
-  let%lwt files = Lazy.force files in
   List.filter_map (fun file ->
     match String.split_on_char '/' file with
     | [_switch; _name; ""] -> None
     | [switch'; name'; pkg] when String.equal switch switch' && String.equal name name' -> Some pkg
     | _ -> None
-  ) files |>
-  Lwt.return
+  ) files
 
 let goodfiles = get_files ~name:"good"
 let partialfiles = get_files ~name:"partial"
@@ -77,13 +78,11 @@ let notavailablefiles = get_files ~name:"not-available"
 let internalfailurefiles = get_files ~name:"internal-failure"
 
 let logdir_get_compilers (Logdir (_, _, _, _, files)) =
-  let%lwt files = Lazy.force files in
   List.filter_map (fun file ->
     match String.split_on_char '/' file with
     | [switch; ""] -> Some (Intf.Compiler.from_string switch)
     | _ -> None
-  ) files |>
-  Lwt.return
+  ) files
 
 let logdir_get_content ~comp ~state ~pkg = function
   | Logdir (Uncompressed, _, _, workdir, _) as logdir ->

--- a/lib/server_workdirs.mli
+++ b/lib/server_workdirs.mli
@@ -15,13 +15,13 @@ val get_logdir_name : logdir -> string
 val get_logdir_hash : logdir -> string
 val get_logdir_time : logdir -> float
 
-val goodfiles : switch:Intf.Compiler.t -> logdir -> string list Lwt.t
-val partialfiles : switch:Intf.Compiler.t -> logdir -> string list Lwt.t
-val badfiles : switch:Intf.Compiler.t -> logdir -> string list Lwt.t
-val notavailablefiles : switch:Intf.Compiler.t -> logdir -> string list Lwt.t
-val internalfailurefiles : switch:Intf.Compiler.t -> logdir -> string list Lwt.t
+val goodfiles : switch:Intf.Compiler.t -> logdir -> string list
+val partialfiles : switch:Intf.Compiler.t -> logdir -> string list
+val badfiles : switch:Intf.Compiler.t -> logdir -> string list
+val notavailablefiles : switch:Intf.Compiler.t -> logdir -> string list
+val internalfailurefiles : switch:Intf.Compiler.t -> logdir -> string list
 val logdir_get_content : comp:Intf.Compiler.t -> state:Intf.State.t -> pkg:string -> logdir -> string Lwt.t
-val logdir_get_compilers : logdir -> Intf.Compiler.t list Lwt.t
+val logdir_get_compilers : logdir -> Intf.Compiler.t list
 val logdir_move : switches:Intf.Compiler.t list -> logdir -> unit Lwt.t
 val logdir_search : switch:string -> regexp:string -> logdir -> string list Lwt.t
 

--- a/server/lib/cache.ml
+++ b/server/lib/cache.ml
@@ -59,7 +59,7 @@ type 'a prefetched_or_recompute =
 type data = {
   mutable logdirs : Server_workdirs.logdir list Lwt.t;
   mutable pkgs : (Server_workdirs.logdir * Intf.Pkg.t list Lwt.t prefetched_or_recompute) list Lwt.t;
-  mutable compilers : (Server_workdirs.logdir * Intf.Compiler.t list Lwt.t Lazy.t) list Lwt.t;
+  mutable compilers : (Server_workdirs.logdir * Intf.Compiler.t list) list Lwt.t;
   mutable opams : OpamFile.OPAM.t Opams_cache.t Lwt.t;
   mutable revdeps : int Revdeps_cache.t Lwt.t;
 }
@@ -89,20 +89,16 @@ let clear_and_init r_self ~pkgs ~compilers ~logdirs ~opams ~revdeps =
   self.logdirs <- logdirs ();
   self.compilers <- begin
     let%lwt logdirs = self.logdirs in
-    List.map (fun logdir ->
-      let c = lazy (compilers logdir) in
-      (logdir, c)
-    ) logdirs |>
-    Lwt.return
+    Lwt_list.map_s (fun logdir ->
+      let%lwt c = compilers logdir in
+      Lwt.return (logdir, c)
+    ) logdirs
   end;
   self.pkgs <- begin
     let%lwt compilers = self.compilers in
     List.mapi (fun i (logdir, compilers) ->
       let p =
-        let aux () =
-          let%lwt compilers = Lazy.force compilers in
-          pkgs ~compilers logdir
-        in
+        let aux () = pkgs ~compilers logdir in
         match i with
         | 0 | 1 -> Prefetched (aux ())
         | _ -> Recompute aux
@@ -247,7 +243,7 @@ let get_pkgs ~logdir self =
 let get_compilers ~logdir self =
   let%lwt self = !self in
   let%lwt compilers = self.compilers in
-  Lazy.force (List.assoc ~eq:Server_workdirs.logdir_equal logdir compilers)
+  Lwt.return (List.assoc ~eq:Server_workdirs.logdir_equal logdir compilers)
 
 let get_opam self k =
   let%lwt self = !self in

--- a/server/lib/cache.mli
+++ b/server/lib/cache.mli
@@ -1,5 +1,5 @@
-module Opams_cache : Hashtbl.S with type key = string
-module Revdeps_cache : Hashtbl.S with type key = string
+module Opams_cache : Map.S with type key = string
+module Revdeps_cache : Map.S with type key = string
 
 type t
 


### PR DESCRIPTION
On the main instance of opam-health-check, RAM usage after the cache prefetching could reach 35% of RAM.
By default the OCaml GC can take up to 120% the current amount of RAM the program takes (see `Gc.space_overhead`), which means the program would reach 77% of RAM after a day or two. That's even without counting some of the lazy cache values that can be added to the total amount of memory taken when a user reaches for an older page (which bots do!)

This PR makes it so that the amount of memory taken is fixed (no more lazy) and much lower (down to 10.5% of RAM), which with OCaml's default 120% `space_overhead` value, the max amount of RAM taken is about 24% of total RAM on the machine.