### PR TITLE
Extend API to get previous run results

### DIFF
--- a/server/lib/cache.ml
+++ b/server/lib/cache.ml
@@ -284,3 +284,15 @@ let get_json_latest_packages self =
     Lwt.return (Yojson.Safe.to_string json)
   in
   Lwt.return json
+
+  let get_json_run_packages self logdir =
+    let%lwt self = !self in
+    let%lwt json =
+      let%lwt pkgs =
+        let%lwt pkgs = self.pkgs in
+        get_or_recompute (List.assoc ~eq:Server_workdirs.logdir_equal logdir pkgs)
+      in
+      let json = Json.pkgs_to_json pkgs in
+      Lwt.return (Yojson.Safe.to_string json)
+    in
+    Lwt.return json

--- a/server/lib/cache.mli
+++ b/server/lib/cache.mli
@@ -25,3 +25,4 @@ val get_html_diff : conf:Server_configfile.t -> old_logdir:Server_workdirs.logdi
 val get_html_diff_list : t -> string Lwt.t
 val get_html_run_list : t -> string Lwt.t
 val get_json_latest_packages : t -> string Lwt.t
+val get_json_run_packages : t -> Server_workdirs.logdir -> string Lwt.t

--- a/server/lib/server.ml
+++ b/server/lib/server.ml
@@ -149,6 +149,14 @@ module Make (Backend : Backend_intf.S) = struct
     | ["api"; "v1"; "latest"; "packages"] ->
         let%lwt json = Cache.get_json_latest_packages Backend.cache in
         serv_text ~content_type:"application/json" json
+    | ["api"; "v1"; logdir; "packages"] ->
+      begin match%lwt get_logdir logdir with
+      | None ->
+        Cohttp_lwt_unix.Server.respond ~body:`Empty ~status:`Not_found ()
+      | Some logdir ->
+          let%lwt json = Cache.get_json_run_packages Backend.cache logdir in
+          serv_text ~content_type:"application/json" json
+      end
     | _ ->
         Cohttp_lwt_unix.Server.respond ~body:`Empty ~status:`Not_found ()
 


### PR DESCRIPTION
Disclaimer: This was not tested! 

For instance:

http://check.ocamllabs.io/api/v1/1670612392-3a8f24e33beda3fd110c63f455e18cb232f84b62/package