### PR TITLE
Add note to let users know about long startup time

### DIFF
--- a/server/backend/check.ml
+++ b/server/backend/check.ml
@@ -287,6 +287,7 @@ let get_obuilder ~conf ~opam_repo ~opam_repo_commit ~extra_repos switch =
 let get_pkgs ~debug ~cap ~conf ~stderr (switch, base_obuilder) =
   let switch = Intf.Compiler.to_string (Intf.Switch.name switch) in
   let%lwt () = Lwt_io.write_line stderr ("Getting packages list for "^switch^"…") in
+  let%lwt () = Lwt_io.write_line stderr ("Note that this may take an hour or two.") in
   let%lwt pkgs = ocluster_build_str ~important:true ~debug ~cap ~conf ~base_obuilder ~stderr ~default:None (Server_configfile.list_command conf) in
   let pkgs = List.filter begin fun pkg ->
     Oca_lib.is_valid_filename pkg &&

--- a/server/backend/check.ml
+++ b/server/backend/check.ml
@@ -286,8 +286,7 @@ let get_obuilder ~conf ~opam_repo ~opam_repo_commit ~extra_repos switch =
 
 let get_pkgs ~debug ~cap ~conf ~stderr (switch, base_obuilder) =
   let switch = Intf.Compiler.to_string (Intf.Switch.name switch) in
-  let%lwt () = Lwt_io.write_line stderr ("Getting packages list for "^switch^"…") in
-  let%lwt () = Lwt_io.write_line stderr ("Note that this may take an hour or two.") in
+  let%lwt () = Lwt_io.write_line stderr ("Getting packages list for "^switch^"… (this may take an hour or two)") in
   let%lwt pkgs = ocluster_build_str ~important:true ~debug ~cap ~conf ~base_obuilder ~stderr ~default:None (Server_configfile.list_command conf) in
   let pkgs = List.filter begin fun pkg ->
     Oca_lib.is_valid_filename pkg &&


### PR DESCRIPTION
When the run starts, neither `opam-health-check log` nor querying the Web interface is very informative.

```
$ opam-health-check log
Sending command…
Getting packages list for 5.0.0…
Getting packages list for 5.0.0+more_volatile…
```

```
$ curl http://localhost:8080/
opam-health-check: no run exist, please wait for the first run to finish. Please look at the documentation to learn how to start it.
```

The idea here is to add an output line telling people to be patient for an hour or two.