### PR TITLE
Add possibility to specify rank of an extra repository

### DIFF
--- a/lib/intf.ml
+++ b/lib/intf.ml
@@ -89,15 +89,17 @@ module Repository = struct
     name : string;
     github : Github.t;
     for_switches : Compiler.t list option;
+    rank : int;
   }
 
-  let create ~name ~github ~for_switches =
+  let create ~name ~github ~for_switches ~rank =
     let github = Github.create github in
-    {name; github; for_switches}
+    {name; github; for_switches; rank}
 
   let name {name; _} = name
   let github {github; _} = github
   let for_switches {for_switches; _} = for_switches
+  let rank {rank; _} = rank
 end
 
 module Log = struct

--- a/lib/intf.mli
+++ b/lib/intf.mli
@@ -49,11 +49,12 @@ end
 module Repository : sig
   type t
 
-  val create : name:string -> github:string -> for_switches:Compiler.t list option -> t
+  val create : name:string -> github:string -> for_switches:Compiler.t list option -> rank:int -> t
 
   val name : t -> string
   val github : t -> Github.t
   val for_switches : t -> Compiler.t list option
+  val rank : t -> int
 end
 
 module Log : sig

--- a/lib/server_configfile.ml
+++ b/lib/server_configfile.ml
@@ -83,7 +83,8 @@ let get_repo = function
         | `String rank -> (
             try int_of_string rank
             with Failure _ -> failwith "unexpected non-integer value for key 'rank'")
-        | _ | exception Not_found -> 1
+        | _ -> failwith "unexpected non-integer value for key 'rank'"
+        | exception Not_found -> 1
       in
       Intf.Repository.create ~name ~github ~for_switches ~rank
   | `O [name, `O [("github", `String github); ("for-switches", `A for_switches)]] ->

--- a/server/backend/check.ml
+++ b/server/backend/check.ml
@@ -250,8 +250,9 @@ let get_obuilder ~conf ~opam_repo ~opam_repo_commit ~extra_repos switch =
       List.map (fun (repo, hash) ->
         let name = Filename.quote (Intf.Repository.name repo) in
         let url = Intf.Github.url (Intf.Repository.github repo) in
+        let rank = Intf.Repository.rank repo in
         [ run ~network "git clone -q '%s' ~/%s && git -C ~/%s checkout -q %s" url name name hash;
-          run "opam repository add --dont-select %s ~/%s" name name;
+          run "opam repository add --dont-select --rank=%d %s ~/%s" rank name name;
         ]
       ) extra_repos
     ) @ [


### PR DESCRIPTION
This is an attempt to add the possibility to specify ranks in `extra_repositories`.

Currently, by default, extra repositories take precedence over the `default` repository. I’ve been bitten by this: I was comparing two compiler switches, one with an extra repo and one without. The extra repo happened to be a fork of `default` but was about 1 month of commits behind `default`. As a consequence, the switch with the extra repo was missing some updates to the package files, such as https://github.com/ocaml/opam-repository/commit/c8b0b2cb9afd6b89c7dd5ccc79f1c752ca4dbde7.

This should be avoidable by specifying the rank of such extra repos to be 2, letting `default` take precedence when both repos have the same package at the same version.

In fact, I think this should be the default behavior (i.e. `rank` should default to 2 for extra repos), but this is not strictly backward-compatible, so for now I use 1 as the default.

I have not tested this yet.