### PR TITLE
FreeBSD and macOS support

### DIFF
--- a/server/backend/check.ml
+++ b/server/backend/check.ml
@@ -247,14 +247,14 @@ let get_obuilder ~conf ~opam_repo ~opam_repo_commit ~extra_repos switch =
   let distribution = Server_configfile.platform_distribution conf in
   let from = match os with
     | "linux" -> "ocaml/opam:"^distribution (* typically this is 'debian-unstable' which is 5.0.0 *)
-    | "freebsd" -> distribution^"-ocaml-5.0" (* Either 4.14.1 or 5.0.0 could be selected *)
-    | "macos" -> "macos-"^distribution^"-ocaml-5.0" (* Either 4.14.1 or 5.0.0 could be selected *)
+    | "freebsd" -> distribution
+    | "macos" -> "macos-"^distribution
     | os -> failwith ("OS '"^os^"' not supported") (* TODO: Should other platforms simply take the same ocurrent/opam: prefix? *)
   in
   let ln_opam = match os with
     | "linux" -> "sudo ln -f /usr/bin/opam-dev /usr/bin/opam"
-    | "freebsd" -> "sudo ln -f /usr/local/bin/opam-2.1 /usr/local/bin/opam"
-    | "macos" -> "ln -f ~/local/bin/opam-2.1 ~/local/bin/opam"
+    | "freebsd" -> "sudo ln -f /usr/local/bin/opam-dev /usr/local/bin/opam"
+    | "macos" -> "ln -f ~/local/bin/opam-dev ~/local/bin/opam"
     | os -> failwith ("OS '"^os^"' not supported")
   in
   let opam_init_options = match os with

--- a/server/backend/check.ml
+++ b/server/backend/check.ml
@@ -236,7 +236,7 @@ let get_obuilder ~conf ~opam_repo ~opam_repo_commit ~extra_repos switch =
   let is_macos = String.equal os "macos" in
   let from = match os  with
     | "linux" -> "ocaml/opam:"^Server_configfile.platform_distribution conf
-    | "macos" -> "macos-"^Server_configfile.platform_distribution conf^"-ocaml-4.13" (*TODO: Will macOS cope with creating a new switch... *)
+    | "macos" -> "macos-"^Server_configfile.platform_distribution conf^"-ocaml-5.0" (*TODO: Will macOS cope with creating a new switch... *)
     | os -> failwith ("OS '"^os^"' not supported") (* TODO: Should other platforms simply take the same ocurrent/opam: prefix? *)
   in
   let prefix = if is_macos then "~/local" else "/usr" in

--- a/server/backend/check.ml
+++ b/server/backend/check.ml
@@ -232,19 +232,23 @@ let get_obuilder ~conf ~opam_repo ~opam_repo_commit ~extra_repos switch =
   in
   let open Obuilder_spec in
   let cache = cache ~conf in
-  let from = match Server_configfile.platform_os conf with
-    | "linux" -> Server_configfile.platform_image conf
+  let os = Server_configfile.platform_os conf in
+  let is_macos = String.equal os "macos" in
+  let from = match os  with
+    | "linux" -> "ocaml/opam:"^Server_configfile.platform_distribution conf
+    | "macos" -> "macos-"^Server_configfile.platform_distribution conf^"-ocaml-4.13" (*TODO: Will macOS cope with creating a new switch... *)
     | os -> failwith ("OS '"^os^"' not supported") (* TODO: Should other platforms simply take the same ocurrent/opam: prefix? *)
   in
+  let prefix = if is_macos then "~/local" else "/usr" in
   stage ~from begin
     [ user_unix ~uid:1000 ~gid:1000;
       env "OPAMPRECISETRACKING" "1"; (* NOTE: See https://github.com/ocaml/opam/issues/3997 *)
       env "OPAMUTF8" "never"; (* Disable UTF-8 characters so that output stay consistant accross platforms *)
       env "OPAMEXTERNALSOLVER" "builtin-0install";
       env "OPAMCRITERIA" "+removed";
-      run "sudo ln -f /usr/bin/opam-dev /usr/bin/opam";
+      run "%sln -f %s/bin/opam-2.1 %s/bin/opam" (if is_macos then "" else "sudo ") prefix prefix;
       run ~network "rm -rf ~/opam-repository && git clone -q '%s' ~/opam-repository && git -C ~/opam-repository checkout -q %s" (Intf.Github.url opam_repo) opam_repo_commit;
-      run "rm -rf ~/.opam && opam init -ya --bare --config ~/.opamrc-sandbox ~/opam-repository";
+      run "rm -rf ~/.opam && opam init -ya --bare%s ~/opam-repository" (if is_macos then "" else "--config ~/.opamrc-sandbox");
     ] @
     List.flatten (
       List.map (fun (repo, hash) ->

--- a/server/backend/check.ml
+++ b/server/backend/check.ml
@@ -4,7 +4,7 @@ let cache ~conf =
   let os = Server_configfile.platform_os conf in
   let opam_cache = match os with
     | "linux"
-    | "freebsd" -> Some (Obuilder_spec.Cache.v "opam-archives" ~target:"/home/opam/.opam/download-cache")
+    | "freebsd" -> Some (Obuilder_spec.Cache.v "opam-archives" ~target:"/usr/home/opam/.opam/download-cache")
     | "macos" -> Some (Obuilder_spec.Cache.v "opam-archives" ~target:"/Users/mac1000/.opam/download-cache")
     | os -> failwith ("Opam cache not supported on '" ^ os) (* TODO: Should other platforms simply take the same ocurrent/opam: prefix? *) in
   let brew_cache = match os with

--- a/server/backend/check.ml
+++ b/server/backend/check.ml
@@ -3,17 +3,18 @@ let fmt = Printf.sprintf
 let cache ~conf =
   let os = Server_configfile.platform_os conf in
   let opam_cache = match os with
-    | "linux" -> Obuilder_spec.Cache.v "opam-archives" ~target:"/home/opam/.opam/download-cache"
-    | "macos" -> Obuilder_spec.Cache.v "opam-archives" ~target:"/Users/mac1000/.opam/download-cache"
+    | "linux"
+    | "freebsd" -> Some (Obuilder_spec.Cache.v "opam-archives" ~target:"/home/opam/.opam/download-cache")
+    | "macos" -> Some (Obuilder_spec.Cache.v "opam-archives" ~target:"/Users/mac1000/.opam/download-cache")
     | os -> failwith ("Opam cache not supported on '" ^ os) (* TODO: Should other platforms simply take the same ocurrent/opam: prefix? *) in
   let brew_cache = match os with
-    | "macos" -> Obuilder_spec.Cache.v "homebrew" ~target:"/Users/mac1000/Library/Caches/Homebrew"
-    | os -> failwith ("Brew cache not supported on '" ^ os) (* TODO: Should other platforms simply take the same ocurrent/opam: prefix? *) in
-  if Server_configfile.enable_dune_cache conf then
-    let dune_cache = Obuilder_spec.Cache.v "opam-dune-cache" ~target:"/home/opam/.cache/dune" in
-    [opam_cache; dune_cache]
-  else
-    [opam_cache; brew_cache]
+    | "macos" -> Some (Obuilder_spec.Cache.v "homebrew" ~target:"/Users/mac1000/Library/Caches/Homebrew")
+    | _ -> None in
+  let dune_cache =
+    if Server_configfile.enable_dune_cache conf then
+      Some (Obuilder_spec.Cache.v "opam-dune-cache" ~target:"/home/opam/.cache/dune")
+    else None in
+  List.filter_map (fun x -> x) [opam_cache; brew_cache; dune_cache]
 
 let network = ["host"]
 
@@ -241,21 +242,28 @@ let get_obuilder ~conf ~opam_repo ~opam_repo_commit ~extra_repos switch =
   let cache = cache ~conf in
   let os = Server_configfile.platform_os conf in
   let is_macos = String.equal os "macos" in
+  let is_freebsd = String.equal os "freebsd" in
   let from = match os  with
     | "linux" -> "ocaml/opam:"^Server_configfile.platform_distribution conf
+    | "freebsd" -> (Server_configfile.platform_distribution conf)^"-ocaml-4.14"
     | "macos" -> "macos-"^Server_configfile.platform_distribution conf^"-ocaml-5.0" (*TODO: Will macOS cope with creating a new switch... *)
     | os -> failwith ("OS '"^os^"' not supported") (* TODO: Should other platforms simply take the same ocurrent/opam: prefix? *)
   in
-  let prefix = if is_macos then "~/local" else "/usr" in
+  let opam = match os with
+    | "linux" -> "sudo ln -f /usr/bin/opam-2.1 /usr/bin/opam"
+    | "freebsd" -> "sudo ln -f /usr/local/bin/opam-2.1 /usr/local/bin/opam"
+    | "macos" -> "ln -f ~/local/bin/opam-2.1 ~/local/usr/bin/opam"
+    | _ -> ""
+  in
   stage ~from begin
     [ user_unix ~uid:1000 ~gid:1000;
       env "OPAMPRECISETRACKING" "1"; (* NOTE: See https://github.com/ocaml/opam/issues/3997 *)
       env "OPAMUTF8" "never"; (* Disable UTF-8 characters so that output stay consistant accross platforms *)
       env "OPAMEXTERNALSOLVER" "builtin-0install";
       env "OPAMCRITERIA" "+removed";
-      run "%sln -f %s/bin/opam-2.1 %s/bin/opam" (if is_macos then "" else "sudo ") prefix prefix;
+      run "%s" opam;
       run ~network "rm -rf ~/opam-repository && git clone -q '%s' ~/opam-repository && git -C ~/opam-repository checkout -q %s" (Intf.Github.url opam_repo) opam_repo_commit;
-      run "rm -rf ~/.opam && opam init -ya --bare%s ~/opam-repository" (if is_macos then "" else "--config ~/.opamrc-sandbox");
+      run "rm -rf ~/.opam && opam init -ya --bare %s ~/opam-repository" (if is_macos || is_freebsd then "" else "--config ~/.opamrc-sandbox");
     ] @
     List.flatten (
       List.map (fun (repo, hash) ->

--- a/server/backend/check.ml
+++ b/server/backend/check.ml
@@ -1,12 +1,19 @@
 let fmt = Printf.sprintf
 
 let cache ~conf =
-  let opam_cache = Obuilder_spec.Cache.v "opam-archives" ~target:"/home/opam/.opam/download-cache" in
+  let os = Server_configfile.platform_os conf in
+  let opam_cache = match os with
+    | "linux" -> Obuilder_spec.Cache.v "opam-archives" ~target:"/home/opam/.opam/download-cache"
+    | "macos" -> Obuilder_spec.Cache.v "opam-archives" ~target:"/Users/mac1000/.opam/download-cache"
+    | os -> failwith ("Opam cache not supported on '" ^ os) (* TODO: Should other platforms simply take the same ocurrent/opam: prefix? *) in
+  let brew_cache = match os with
+    | "macos" -> Obuilder_spec.Cache.v "homebrew" ~target:"/Users/mac1000/Library/Caches/Homebrew"
+    | os -> failwith ("Brew cache not supported on '" ^ os) (* TODO: Should other platforms simply take the same ocurrent/opam: prefix? *) in
   if Server_configfile.enable_dune_cache conf then
     let dune_cache = Obuilder_spec.Cache.v "opam-dune-cache" ~target:"/home/opam/.cache/dune" in
     [opam_cache; dune_cache]
   else
-    [opam_cache]
+    [opam_cache; brew_cache]
 
 let network = ["host"]
 


### PR DESCRIPTION
This PR adds support for macOS and FreeBSD.

### FreeBSD

```
platform:
  os: freebsd
  arch: x86_64
  distribution: freebsd
```

### macOS

```
platform:
  os: macos
  arch: x86_64
  distribution: homebrew
```

As worker pools for these systems have a low capacity, it will not be practical to run these very frequently or against an extensive collection of compilers; however, limiting the selection to the latest compiler and package version may still provide some insights.  This `list-command` selects just the latest version.

```
list-command: opam list --available --installable --columns=package --short
```

These health checks can also be helpful when testing ocluster workers.

My latest run on FreeBSD can be seen here: http://freebsd-health-check.ocamllabs.io:8080/