### PR TITLE
Enable -warn-error +partial-match by default to ensure changes in a dependency do not lead into unforseen runtime failures

### DIFF
--- a/server/backend/check.ml
+++ b/server/backend/check.ml
@@ -308,7 +308,9 @@ let get_obuilder ~conf ~opam_repo ~opam_repo_commit ~extra_repos switch =
        ]
      else
        []
-    )
+    ) @ [
+      env "OCAMLPARAM" "warn-error=+8,_"; (* https://github.com/ocaml/ocaml/issues/12475 *)
+    ]
   end
 
 let get_pkgs ~debug ~cap ~conf ~stderr (switch, base_obuilder) =


### PR DESCRIPTION
Same as https://github.com/ocurrent/opam-repo-ci/pull/242