### PR TITLE
Add netbase

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /src/
 RUN opam exec -- dune build --release @install
 
 FROM debian:12
-RUN apt-get update && apt-get install dumb-init libev-dev ca-certificates xz-utils tar pixz ugrep -y --no-install-recommends
+RUN apt-get update && apt-get install netbase dumb-init libev-dev ca-certificates xz-utils tar pixz ugrep -y --no-install-recommends
 WORKDIR /var/lib/opam-health-check
 ENTRYPOINT ["dumb-init", "/usr/local/bin/opam-health-serve"]
 ENV OCAMLRUNPARAM=b


### PR DESCRIPTION
This PR adds the package `netbase`.  Without this package `opam-health-check` fails with the error `unknown scheme`

```shell
# opam-health-check clear-cache
Sending command…
opam-health-check: internal error, uncaught exception:
                   Failure("resolution failed: unknown scheme")
                   Raised at Client.send_msg.(fun) in file "client/client.ml", line 48, characters 4-108
                   Re-raised at Lwt.Miscellaneous.poll in file "src/core/lwt.ml", line 3077, characters 20-29
                   Called from Lwt_main.run.run_loop in file "src/unix/lwt_main.ml", line 31, characters 10-20
                   Called from Lwt_main.run in file "src/unix/lwt_main.ml", line 118, characters 8-13
                   Re-raised at Lwt_main.run in file "src/unix/lwt_main.ml", line 124, characters 4-13
                   Called from Cmdliner_term.app.(fun) in file "cmdliner_term.ml", line 24, characters 19-24
                   Called from Cmdliner_eval.run_parser in file "cmdliner_eval.ml", line 34, characters 37-44
```