### PR TITLE
Revert "Enable -warn-error +partial-match by default to ensure change…

### DIFF
--- a/server/backend/check.ml
+++ b/server/backend/check.ml
@@ -308,9 +308,7 @@ let get_obuilder ~conf ~opam_repo ~opam_repo_commit ~extra_repos switch =
        ]
      else
        []
-    ) @ [
-      env "OCAMLPARAM" "warn-error=+8,_"; (* https://github.com/ocaml/ocaml/issues/12475 *)
-    ]
+    )
   end
 
 let get_pkgs ~debug ~cap ~conf ~stderr (switch, base_obuilder) =


### PR DESCRIPTION
…s in a dependency do not lead into unforseen runtime failures"

This reverts commit 1597f629c04c0a574526501d244b0f7eecea0a54.

See https://github.com/ocurrent/opam-health-check/issues/68