### PR TITLE
Build failure fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ocaml/opam:debian-12-ocaml-4.14@sha256:f2058e217865907102f49886543f7c92952ec990ddfb1ee9c5e9d82e55457778 AS build
 RUN sudo apt-get update
 RUN sudo ln -f /usr/bin/opam-2.2 /usr/bin/opam && opam init --reinit -n
-RUN cd ~/opam-repository && git fetch origin master && git reset --hard e2e8f58bc257422abfd1132c3363e5b7ed2226db && opam update
+RUN cd ~/opam-repository && git fetch origin master && git reset --hard 95944fff7d6ad34fbe8e859c3c150931a3ead71d && opam update
 COPY --chown=opam opam-health-check.opam /src/
 RUN opam install --deps-only /src/
 COPY --chown=opam . /src/

--- a/client/client.ml
+++ b/client/client.ml
@@ -1,7 +1,7 @@
 let parse_key key =
   let key = IO.with_in (Fpath.to_string key) (IO.read_all ?size:None) in
   let key =
-    match X509.Private_key.decode_pem (Cstruct.of_string key) with
+    match X509.Private_key.decode_pem key with
     | Ok `RSA key -> key
     | Ok _ -> failwith "unsupported key type, only RSA supported"
     | Error `Msg m -> failwith ("error decoding key: " ^ m)
@@ -9,7 +9,7 @@ let parse_key key =
   Mirage_crypto_pk.Rsa.pub_of_priv key
 
 let partial_encrypt key msg =
-  Cstruct.to_string (Mirage_crypto_pk.Rsa.encrypt ~key (Cstruct.of_string msg))
+  Mirage_crypto_pk.Rsa.encrypt ~key msg
 
 let rec encrypt_msg ~key msg =
   let max_size = Mirage_crypto_pk.Rsa.pub_bits key / 8 in

--- a/opam-health-check.opam
+++ b/opam-health-check.opam
@@ -46,6 +46,7 @@ depends: [
   "lwt"
   "lwt_ppx"
   "uri"
+  "x509" {>= "1.0.0"}
   "docker_hub" {>= "0.1.0" & < "0.2.0"}
   "memtrace" {>= "0.2.3"}
   "tls-lwt" {>= "0.16.0"} # activate conduit with TLS for slack webhooks

--- a/opam-health-check.opam
+++ b/opam-health-check.opam
@@ -42,7 +42,7 @@ depends: [
   "cstruct"
   "capnp-rpc" {>= "1.2"}
   "capnp-rpc-lwt" {>= "1.2"}
-  "capnp-rpc-unix" {>= "1.2"}
+  "capnp-rpc-unix" {>= "1.2" & < "2.0"}
   "lwt"
   "lwt_ppx"
   "uri"

--- a/opam-health-check.opam
+++ b/opam-health-check.opam
@@ -23,7 +23,7 @@ depends: [
   "opam-core" {>= "2.2"}
   "opam-format" {>= "2.2"}
   "mirage-crypto-pk" {>= "0.11.0"}
-  "mirage-crypto-rng" {>= "0.11.0"}
+  "mirage-crypto-rng" {>= "0.11.0" & < "1.2.0"}
   "mirage-crypto-rng-lwt" {>= "0.11.0"}
   "cmdliner" {>= "1.1.0"}
   "prometheus-app" {>= "1.2"}

--- a/server/backend/admin.ml
+++ b/server/backend/admin.ml
@@ -20,7 +20,7 @@ let create_userkey workdir username =
   let key = Mirage_crypto_pk.Rsa.generate ~bits:2048 () in
   let key_pem = X509.Private_key.encode_pem (`RSA key) in
   with_file_out ~flags:[Unix.O_EXCL] (Fpath.to_string keyfile) begin fun chan ->
-    Lwt_io.write_line chan (Cstruct.to_string key_pem)
+    Lwt_io.write_line chan key_pem
   end
 
 let create_admin_key workdir =
@@ -126,13 +126,13 @@ let get_user_key workdir user =
   let keyfile = get_keyfile workdir user in
   let%lwt key = Lwt_io.with_file ~mode:Lwt_io.Input (Fpath.to_string keyfile) (Lwt_io.read ?count:None) in
   Lwt.return
-    (match X509.Private_key.decode_pem (Cstruct.of_string key) with
+    (match X509.Private_key.decode_pem key with
      | Ok `RSA key -> key
      | Ok _ -> failwith "unsupported key type, only RSA supported"
      | Error `Msg m -> failwith ("error decoding key: " ^ m))
 
-let partial_decrypt key msg =
-  Cstruct.to_string (Mirage_crypto_pk.Rsa.decrypt ~key (Cstruct.of_string msg))
+let partial_decrypt key =
+  Mirage_crypto_pk.Rsa.decrypt ~key
 
 let rec decrypt key msg =
   let key_size = Mirage_crypto_pk.Rsa.priv_bits key / 8 in


### PR DESCRIPTION
While trying to install and build it on I ran across a couple of issues:

1. X509 1.0 changed API a bit so I updated to the new API. Fairly straightforward
2. capnproto-rpc 2.0 changed API quite significantly so for now I changed the constraint to avoid the issue.