### PR TITLE
Ignore OPAM local switch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 _build
+_opam
 .merlin
 *.install
 .vscode


### PR DESCRIPTION
Gitignoring _opam helps e.g. `rg` from finding hits in the local switch.