### PR TITLE
Port from custom PPX to let operator

### DIFF
--- a/client/dune
+++ b/client/dune
@@ -1,7 +1,6 @@
 (executable
   (name client)
   (public_name opam-health-check)
-  (preprocess (pps lwt_ppx))
   (libraries
     mirage-crypto-pk
     cohttp

--- a/opam-health-check.opam
+++ b/opam-health-check.opam
@@ -43,8 +43,7 @@ depends: [
   "capnp-rpc" {>= "1.2"}
   "capnp-rpc-lwt" {>= "1.2"}
   "capnp-rpc-unix" {>= "1.2" & < "2.0"}
-  "lwt"
-  "lwt_ppx"
+  "lwt" {>= "5.3.0"}
   "uri"
   "x509" {>= "1.0.0"}
   "docker_hub" {>= "0.1.0" & < "0.2.0"}

--- a/server/backend/dune
+++ b/server/backend/dune
@@ -1,6 +1,5 @@
 (library
   (name backend)
-  (preprocess (pps lwt_ppx))
   (libraries
     oca_lib
     fmt

--- a/server/dune
+++ b/server/dune
@@ -1,7 +1,6 @@
 (executable
   (name main)
   (public_name opam-health-serve)
-  (preprocess (pps lwt_ppx))
   (libraries backend lwt.unix containers cmdliner oca_server memtrace))
 
 (rule

--- a/server/lib/cache.ml
+++ b/server/lib/cache.ml
@@ -1,3 +1,4 @@
+open Lwt.Syntax
 open Intf
 
 module Opams_cache = Map.Make (String)
@@ -84,47 +85,46 @@ let clear_and_init r_self ~pkgs ~compilers ~logdirs ~opams ~revdeps =
   let self = create_data () in
   let mvar = Lwt_mvar.create_empty () in
   r_self := begin
-    let%lwt () = Lwt_mvar.take mvar in
-    Lwt.return self
+    let+ () = Lwt_mvar.take mvar in
+    self
   end;
   self.opams <- opams ();
   self.revdeps <- revdeps ();
   self.logdirs <- logdirs ();
   self.compilers <- begin
-    let%lwt logdirs = self.logdirs in
+    let* logdirs = self.logdirs in
     Lwt_list.map_s (fun logdir ->
-      let%lwt c = compilers logdir in
-      Lwt.return (logdir, c)
-    ) logdirs
+      let+ c = compilers logdir in
+      logdir, c) logdirs
   end;
   self.pkgs <- begin
-    let%lwt compilers = self.compilers in
+    let* compilers = self.compilers in
     Lwt_list.mapi_s (fun i (logdir, compilers) ->
-      let%lwt p =
+      let* p =
         let aux () = pkgs ~compilers logdir in
         match i with
         | 0 | 1 ->
-            let%lwt p = aux () in
-            Lwt.return (Prefetched p)
+            let+ p = aux () in
+            Prefetched p
         | _ ->
             Lwt.return (Recompute aux)
       in
       Lwt.return (logdir, p)
     ) compilers
   end;
-  let%lwt _ = self.opams in
-  let%lwt _ = self.revdeps in
-  let%lwt _ = self.logdirs in
-  let%lwt _ = self.compilers in
-  let%lwt () = Lwt_mvar.put mvar () in
-  let%lwt _ = self.pkgs in
+  let* _ = self.opams in
+  let* _ = self.revdeps in
+  let* _ = self.logdirs in
+  let* _ = self.compilers in
+  let* () = Lwt_mvar.put mvar () in
+  let* _ = self.pkgs in
   Oca_lib.timer_log timer Lwt_io.stderr "Cache prefetching"
 
 let is_deprecated flag =
   String.equal (OpamTypesBase.string_of_pkg_flag flag) "deprecated"
 
 let (>>&&) x f =
-  let%lwt x = x in
+  let* x = x in
   if x then f () else Lwt.return_false
 
 let must_show_package ~logsearch query ~is_latest pkg =
@@ -170,8 +170,8 @@ let must_show_package ~logsearch query ~is_latest pkg =
   end >>&& begin fun () ->
     match snd query.Html.logsearch with
     | Some _ ->
-        let%lwt logsearch = logsearch in
-        Lwt.return (List.exists (Pkg.equal pkg) logsearch)
+        let+ logsearch = logsearch in
+        List.exists (Pkg.equal pkg) logsearch
     | None -> Lwt.return_true
   end
 
@@ -180,9 +180,10 @@ let filter_pkg ~logsearch query (acc, last) pkg =
     | None -> true
     | Some last -> not (String.equal (Pkg.name pkg) (Pkg.name last))
   in
-  match%lwt must_show_package ~logsearch query ~is_latest pkg with
-  | true -> Lwt.return (pkg :: acc, Some pkg)
-  | false -> Lwt.return (acc, Some pkg)
+  let+ v = must_show_package ~logsearch query ~is_latest pkg in
+  match v with
+  | true -> pkg :: acc, Some pkg
+  | false -> acc, Some pkg
 
 (* TODO: Make use of the cache *)
 let get_logsearch ~query ~logdir =
@@ -190,13 +191,12 @@ let get_logsearch ~query ~logdir =
   | _, None -> Lwt.return []
   | regexp, Some (_, comp) ->
       let switch = Compiler.to_string comp in
-      let%lwt searches = Server_workdirs.logdir_search ~switch ~regexp logdir in
-      List.filter_map (fun s ->
+      let+ searches = Server_workdirs.logdir_search ~switch ~regexp logdir in
+      searches
+      |> List.filter_map (fun s ->
         match String.split_on_char '/' s with
         | [_switch; _state; full_name] -> Some (Pkg.create ~full_name ~instances:[] ~opam:OpamFile.OPAM.empty ~revdeps:(-1))
-        | _ -> None
-      ) searches |>
-      Lwt.return
+        | _ -> None)
 
 let revdeps_cmp p1 p2 =
   Int.neg (Int.compare (Intf.Pkg.revdeps p1) (Intf.Pkg.revdeps p2))
@@ -207,80 +207,76 @@ let get_or_recompute = function
 
 let get_html ~conf self query logdir =
   let aux ~logdir pkgs =
-    let%lwt pkgs = pkgs in
+    let* pkgs = pkgs in
     let logsearch = get_logsearch ~query ~logdir in
-    let%lwt (pkgs, _) = Lwt_list.fold_left_s (filter_pkg ~logsearch query) ([], None) (List.rev pkgs) in
+    let+ (pkgs, _) = Lwt_list.fold_left_s (filter_pkg ~logsearch query) ([], None) (List.rev pkgs) in
     let pkgs = if query.Html.sort_by_revdeps then List.sort revdeps_cmp pkgs else pkgs in
-    let html = Html.get_html ~logdir ~conf query pkgs in
-    Lwt.return html
+    Html.get_html ~logdir ~conf query pkgs
   in
-  let%lwt pkgs = self.pkgs in
+  let* pkgs = self.pkgs in
   let pkgs = List.assoc ~eq:Server_workdirs.logdir_equal logdir pkgs in
   aux ~logdir (get_or_recompute pkgs)
 
 let get_latest_logdir self =
-  let%lwt self = !self in
-  match%lwt self.logdirs with
-  | [] -> Lwt.return None
-  | logdir::_ -> Lwt.return (Some logdir)
+  let* self = !self in
+  let+ v = self.logdirs in
+  match v with
+  | [] -> None
+  | logdir::_ -> Some logdir
 
 let get_html ~conf self query logdir =
-  let%lwt self = !self in
+  let* self = !self in
   get_html ~conf self query logdir
 
 let get_logdirs self =
-  let%lwt self = !self in
+  let* self = !self in
   self.logdirs
 
 let get_pkgs ~logdir self =
-  let%lwt self = !self in
-  let%lwt pkgs = self.pkgs in
+  let* self = !self in
+  let* pkgs = self.pkgs in
   get_or_recompute (List.assoc ~eq:Server_workdirs.logdir_equal logdir pkgs)
 
 let get_compilers ~logdir self =
-  let%lwt self = !self in
-  let%lwt compilers = self.compilers in
-  Lwt.return (List.assoc ~eq:Server_workdirs.logdir_equal logdir compilers)
+  let* self = !self in
+  let+ compilers = self.compilers in
+  List.assoc ~eq:Server_workdirs.logdir_equal logdir compilers
 
 let get_opam self k =
-  let%lwt self = !self in
-  let%lwt opams = self.opams in
-  Lwt.return (Option.get_or ~default:OpamFile.OPAM.empty (Opams_cache.find_opt k opams))
+  let* self = !self in
+  let+ opams = self.opams in
+  Option.get_or ~default:OpamFile.OPAM.empty (Opams_cache.find_opt k opams)
 
 let get_revdeps self k =
-  let%lwt self = !self in
-  let%lwt revdeps = self.revdeps in
-  Lwt.return (Option.get_or ~default:(-1) (Revdeps_cache.find_opt k revdeps))
+  let* self = !self in
+  let+ revdeps = self.revdeps in
+  Option.get_or ~default:(-1) (Revdeps_cache.find_opt k revdeps)
 
 let get_html_diff ~conf ~old_logdir ~new_logdir self =
-  let%lwt old_pkgs = get_pkgs ~logdir:old_logdir self in
-  let%lwt new_pkgs = get_pkgs ~logdir:new_logdir self in
+  let* old_pkgs = get_pkgs ~logdir:old_logdir self in
+  let+ new_pkgs = get_pkgs ~logdir:new_logdir self in
   generate_diff old_pkgs new_pkgs |>
-  Html.get_diff ~conf ~old_logdir ~new_logdir |>
-  Lwt.return
+  Html.get_diff ~conf ~old_logdir ~new_logdir
 
 let get_html_diff_list self =
-  let%lwt self = !self in
-  let%lwt pkgs = self.pkgs in
+  let* self = !self in
+  let+ pkgs = self.pkgs in
   Oca_lib.list_map_cube (fun (new_logdir, _) (old_logdir, _) -> (old_logdir, new_logdir)) pkgs |>
-  Html.get_diff_list |>
-  Lwt.return
+  Html.get_diff_list
 
 let get_html_run_list self =
-  let%lwt self = !self in
-  let%lwt pkgs = self.pkgs in
-  Lwt.return (Html.get_run_list (List.map fst pkgs))
+  let* self = !self in
+  let+ pkgs = self.pkgs in
+  Html.get_run_list (List.map fst pkgs)
 
 let get_json_latest_packages self =
-  let%lwt self = !self in
-  let%lwt json =
-    let%lwt pkgs = match%lwt self.logdirs with
-      | [] -> Lwt.return []
-      | logdir::_ ->
-          let%lwt pkgs = self.pkgs in
-          get_or_recompute (List.assoc ~eq:Server_workdirs.logdir_equal logdir pkgs)
-    in
-    let json = Json.pkgs_to_json pkgs in
-    Lwt.return (Yojson.Safe.to_string json)
+  let* self = !self in
+  let* v = self.logdirs in
+  let+ pkgs = match v with
+    | [] -> Lwt.return []
+    | logdir::_ ->
+        let* pkgs = self.pkgs in
+        get_or_recompute (List.assoc ~eq:Server_workdirs.logdir_equal logdir pkgs)
   in
-  Lwt.return json
+  let json = Json.pkgs_to_json pkgs in
+  Yojson.Safe.to_string json

--- a/server/lib/dune
+++ b/server/lib/dune
@@ -1,7 +1,6 @@
 (library
   (name oca_server)
   (modules_without_implementation backend_intf)
-  (preprocess (pps lwt_ppx))
   (libraries
     lwt
     lwt.unix


### PR DESCRIPTION
With Lwt 5.3 there is support for custom `let` operators so for the sake of readability this PR ports the code to them.

It's a bit of a shame that we don't have custom `match` operators, the remaining features of ppx_lwt like `[%lwt.finally]` or `try%lwt` are not quite as important IMHO. On the other hand, some code was able to use `let+` so a couple of `Lwt.returns` could be scrapped.

In any case this should make it a bit more feature-proof and speed up the build slightly.