### PR TITLE
Update to mirage-crypto 1.2+ API

### DIFF
--- a/opam-health-check.opam
+++ b/opam-health-check.opam
@@ -22,9 +22,9 @@ depends: [
   "containers" {>= "3.4"}
   "opam-core" {>= "2.2"}
   "opam-format" {>= "2.2"}
-  "mirage-crypto-pk" {>= "0.11.0"}
-  "mirage-crypto-rng" {>= "0.11.0" & < "1.2.0"}
-  "mirage-crypto-rng-lwt" {>= "0.11.0"}
+  "mirage-crypto-pk" {>= "1.2.0"}
+  "mirage-crypto-rng" {>= "1.2.0"}
+  "mirage-crypto-rng-lwt" {>= "1.2.0"}
   "cmdliner" {>= "1.1.0"}
   "prometheus-app" {>= "1.2"}
   "fpath"

--- a/server/backend/backend.ml
+++ b/server/backend/backend.ml
@@ -150,7 +150,7 @@ let start ~debug ~cap_file conf workdir =
   let run_trigger = Lwt_mvar.create_empty () in
   let callback = Admin.callback ~on_finished ~conf ~run_trigger workdir in
   Lwt.ignore_result (cache_clear_and_init workdir);
-  Mirage_crypto_rng_lwt.initialize (module Mirage_crypto_rng.Fortuna);
+  Mirage_crypto_rng_unix.use_default ();
   let+ () = Admin.create_admin_key workdir in
   let task () =
     Lwt.join [


### PR DESCRIPTION
It seems mirage-crypto 2.0 will [remove these packages](https://github.com/mirage/mirage-crypto/blob/main/CHANGES.md#v200-2025-02-03) but for now it is fairly easy to migrate.