### PR TITLE
Remove rest of ppx_lwt

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -1,6 +1,4 @@
 (library
  (name oca_lib)
  (wrapped false)
- (preprocess
-  (pps lwt_ppx))
  (libraries lwt lwt.unix opam-core opam-format yaml fpath uri containers))

--- a/lib/server_configfile.ml
+++ b/lib/server_configfile.ml
@@ -1,3 +1,5 @@
+open Lwt.Syntax
+
 type t = {
   yamlfile : Fpath.t;
   mutable name : string option;
@@ -250,7 +252,7 @@ let set_ocaml_switches conf switches =
 
 let set_default_ocaml_switches conf f =
   if Option.is_none conf.ocaml_switches then
-    let%lwt x = f () in
+    let* x = f () in
     set_ocaml_switches conf x
   else
     Lwt.return_unit


### PR DESCRIPTION
In #77 I apparently forgot to remove all ppx_lwt, so the linter rightfully complained that I shouldn't have removed ppx_lwt from the dependencies.

This removes the remaining occurences.