### PR TITLE
Allow building packages via Dune with a new option

### DIFF
--- a/lib/server_configfile.mli
+++ b/lib/server_configfile.mli
@@ -1,5 +1,9 @@
 type t
 
+type build_with =
+  | Opam
+  | Dune
+
 val from_workdir : Server_workdirs.t -> t
 
 val name : t -> string
@@ -24,6 +28,7 @@ val platform_image : t -> string
 val ocaml_switches : t -> Intf.Switch.t list option
 val slack_webhooks : t -> Uri.t list
 val job_timeout : t -> float
+val build_with : t -> build_with
 
 val set_auto_run_interval : t -> int -> unit Lwt.t
 val set_processes : t -> int -> unit Lwt.t

--- a/server/backend/check.ml
+++ b/server/backend/check.ml
@@ -284,8 +284,8 @@ fi |} pkg pkg pkg (Server_configfile.platform_distribution conf)
       String.concat " && " [
         "cd $HOME";
         Printf.sprintf {|opam source %s|} pkg;
-        Printf.sprintf {|opam install %s --depext-only|} pkg;
         Printf.sprintf {|cd %s|} pkg;
+        "opam install ./ --depext-only --with-test";
         set_up_workspace ~conf;
         Printf.sprintf {|%s dune pkg lock|} dune_path;
         Printf.sprintf {|%s dune build|} dune_path]]

--- a/server/backend/check.ml
+++ b/server/backend/check.ml
@@ -284,6 +284,7 @@ fi |} pkg pkg pkg (Server_configfile.platform_distribution conf)
       String.concat " && " [
         "cd $HOME";
         Printf.sprintf {|opam source %s|} pkg;
+        Printf.sprintf {|opam install %s --depext-only|} pkg;
         Printf.sprintf {|cd %s|} pkg;
         set_up_workspace ~conf;
         Printf.sprintf {|%s dune pkg lock|} dune_path;


### PR DESCRIPTION
This adds an option `build-with` which defaults to `opam` at which point it will do the exact same as before. If set to `dune` it will emit different OBuilder instructions to download the sources using `opam` and build them and their dependencies using `dune`.

Some optimizations could be done (e.g. there is no need for a switch in the builder images, however it is cached so the impact isn't too big) but for now this is some starting point that should allow a run and collecting results.

It was tested successfully with `list-command: echo tqdm.0.1` and built the package just fine.