### PR TITLE
Check dune build for installs only

### DIFF
--- a/server/backend/check.ml
+++ b/server/backend/check.ml
@@ -289,7 +289,7 @@ fi |} pkg pkg pkg (Server_configfile.platform_distribution conf)
         "cd $HOME";
         Printf.sprintf {|opam source %s|} pkg;
         Printf.sprintf {|cd %s|} pkg;
-        "opam install ./ --depext-only --with-test";
+        "opam install ./ --depext-only";
         set_up_workspace ~conf;
         Printf.sprintf {|%s dune pkg lock|} dune_path;
         Printf.sprintf {|%s dune build --profile=release @install|} dune_path]]

--- a/server/backend/check.ml
+++ b/server/backend/check.ml
@@ -292,7 +292,7 @@ fi |} pkg pkg pkg (Server_configfile.platform_distribution conf)
         "opam install ./ --depext-only --with-test";
         set_up_workspace ~conf;
         Printf.sprintf {|%s dune pkg lock|} dune_path;
-        Printf.sprintf {|%s dune build|} dune_path]]
+        Printf.sprintf {|%s dune build --profile=release @install|} dune_path]]
     )
 
 let run_job ~cap ~conf ~pool ~debug ~stderr ~base_obuilder ~switch ~num logdir pkg =


### PR DESCRIPTION
A bunch of packages are failing to build, because their tests dependencies are incorrectly specified and/or warnings are treated as errors in the default dune profile. These errors are not really related to dune package management, so perhaps we can be less strict in the healthcheck to help reduce the number of packages we need to look at.