### PR TITLE
Use OPAM-repo metadata when attempting to build a package

### DIFF
--- a/server/backend/check.ml
+++ b/server/backend/check.ml
@@ -311,7 +311,7 @@ fi |} pkg pkg pkg (Server_configfile.platform_distribution conf)
         "opam install ./ --depext-only --with-test --with-doc";
         set_up_workspace ~extra_repos;
         Printf.sprintf {|%s dune pkg lock|} dune_path;
-        Printf.sprintf {|%s dune build --profile=release || echo "opam-health-check: Build failed" && exit 1|} dune_path]]
+        Printf.sprintf {|%s dune build --profile=release || (echo "opam-health-check: Build failed" && exit 1)|} dune_path]]
     )
 
 let run_job ~cap ~conf ~pool ~debug ~stderr ~base_obuilder ~extra_repos ~switch ~num logdir pkg =

--- a/server/backend/check.ml
+++ b/server/backend/check.ml
@@ -286,10 +286,10 @@ fi |} pkg pkg pkg (Server_configfile.platform_distribution conf)
         "cd $HOME";
         Printf.sprintf {|opam source %s|} pkg;
         Printf.sprintf {|cd %s|} pkg;
-        "opam install ./ --depext-only";
+        "opam install ./ --depext-only --with-test";
         set_up_workspace ~extra_repos;
         Printf.sprintf {|%s dune pkg lock|} dune_path;
-        Printf.sprintf {|%s dune build --profile=release @install || echo "opam-health-check: Build failed" && exit 1|} dune_path]]
+        Printf.sprintf {|%s dune build || echo "opam-health-check: Build failed" && exit 1|} dune_path]]
     )
 
 let run_job ~cap ~conf ~pool ~debug ~stderr ~base_obuilder ~extra_repos ~switch ~num logdir pkg =

--- a/server/backend/check.ml
+++ b/server/backend/check.ml
@@ -286,6 +286,8 @@ fi |} pkg pkg pkg (Server_configfile.platform_distribution conf)
         "cd $HOME";
         Printf.sprintf {|opam source %s|} pkg;
         Printf.sprintf {|cd %s|} pkg;
+        (* replace tarball opam metadata with more accurate opam repository metadata *)
+        "for opam in *.opam; do opam show --raw ${opam%.opam} > $opam; done";
         "opam install ./ --depext-only --with-test";
         set_up_workspace ~extra_repos;
         Printf.sprintf {|%s dune pkg lock|} dune_path;

--- a/server/backend/check.ml
+++ b/server/backend/check.ml
@@ -280,7 +280,11 @@ with open("dune-project", "r") as f:
 let remove_packages =
   String.concat " && " [
     "python3 /tmp/opam-health-check-remove-package.py > dune-project-new";
-    "mv dune-project-new dune-project"
+    "mv dune-project-new dune-project";
+    (* remove the python installation after we have used it so packages don't
+       accidentally depend on it without the conf-python3 depext *)
+    "sudo apt-get remove -y python3-sexpdata";
+    "sudo apt-get autoremove -y"
   ]
 
 let run_script ~conf ~extra_repos pkg =

--- a/server/backend/check.ml
+++ b/server/backend/check.ml
@@ -308,10 +308,10 @@ fi |} pkg pkg pkg (Server_configfile.platform_distribution conf)
         (* replace tarball opam metadata with more accurate opam repository metadata *)
         "for opam in *.opam; do opam show --raw ${opam%.opam} > $opam; done";
         remove_packages;
-        "opam install ./ --depext-only --with-test";
+        "opam install ./ --depext-only --with-test --with-doc";
         set_up_workspace ~extra_repos;
         Printf.sprintf {|%s dune pkg lock|} dune_path;
-        Printf.sprintf {|%s dune build || echo "opam-health-check: Build failed" && exit 1|} dune_path]]
+        Printf.sprintf {|%s dune build --profile=release || echo "opam-health-check: Build failed" && exit 1|} dune_path]]
     )
 
 let run_job ~cap ~conf ~pool ~debug ~stderr ~base_obuilder ~extra_repos ~switch ~num logdir pkg =


### PR DESCRIPTION
The reasoning here is that package metadata in the tarball is often invalid and the failures don't really reflect whether the packages build correctly. This is often due to new packages being released which require version constraints applied retroactively or just forgotten dependencies. opam-repository fixes these packages continulously so this PR:

1. Replaces the `opam` files from the tarballs with the ones that `opam` would use.
2. Removes the `package` stanzas from `dune-project` to force Dune to use the dependency information from the OPAM files.