### PR TITLE
Only build the specified package

### DIFF
--- a/server/backend/check.ml
+++ b/server/backend/check.ml
@@ -324,6 +324,9 @@ fi |} pkg pkg pkg (Server_configfile.platform_distribution conf)
         remove_packages;
         set_up_workspace ~extra_repos;
         Printf.sprintf {|%s dune pkg lock|} dune_path;
+        (* avoid invalid dependency hash errors by removing it *)
+        "grep -v dependency_hash dune.lock/lock.dune > lock.dune";
+        "mv lock.dune dune.lock/lock.dune";
         Printf.sprintf {|%s dune build --profile=release --only-packages %s || (echo "opam-health-check: Build failed" && exit 1)|} dune_path pkg_name
       ]])
 


### PR DESCRIPTION
We currently build all the packages in a repository when testing but that will fail all packages in the selection even if just a single package fails to build.

As such this PR aims to reduce the amount of packages that are being built by doing some creative reshuffling.

The reason why it is so complicated is because when we want to build with `--only-packages` we have to make sure to include the local packages that (might) be required (think `foo` and `foo-lwt` which depends on `foo` or for a more real-life example `yojson` and `yojson-five`) but we can't include every package because unrelated packages (`yojson-bench` in my testing example) will fail to build, thus marking all the packages as failures, despite no dependency between them (`yojson-five` doesn't care about `yojson-bench`).