### PR TITLE
Rename `opam` to `pkg_name.opam`

### DIFF
--- a/server/backend/check.ml
+++ b/server/backend/check.ml
@@ -313,6 +313,8 @@ fi |} pkg pkg pkg (Server_configfile.platform_distribution conf)
         "cd $HOME";
         Printf.sprintf {|opam source %s|} pkg;
         Printf.sprintf {|cd %s|} pkg;
+        (* some projects only have a plain opam file, rename to pkg_name.opam is safe *)
+        Printf.sprintf "if [ -f opam ]; then mv opam %s.opam; fi" pkg_name;
         (* replace tarball opam metadata with more accurate opam repository metadata *)
         "for opam in *.opam; do opam show --raw ${opam%.opam} > $opam; done";
         "opam install ./ --depext-only --with-test --with-doc";


### PR DESCRIPTION
While attempting to build `cppo.1.8.0` we fail because the CPPO tarball only has a single `opam` file and all the shell trickery assumes `cppo.opam` exists.

This is the simplest solution to make the rest of the dependency detection code work. It should be safe since the package only contains one opam file thus `pkg_name.opam` never exists in such cases.