### PR TITLE
Differentiate between @install and @default failures

### DIFF
--- a/server/backend/check.ml
+++ b/server/backend/check.ml
@@ -343,7 +343,8 @@ fi |} pkg pkg pkg (Server_configfile.platform_distribution conf)
         (* avoid invalid dependency hash errors by removing the hash *)
         "grep -v dependency_hash dune.lock/lock.dune > /tmp/lock.dune";
         "mv /tmp/lock.dune dune.lock/lock.dune";
-        Printf.sprintf {|%s dune build --profile=release --only-packages $(cat /tmp/packages-for-dune) || (echo "opam-health-check: Build failed" && exit 1)|} dune_path
+        Printf.sprintf {|%s dune build --profile=release --default-target=@install --only-packages $(cat /tmp/packages-for-dune) || (echo "opam-health-check: Build failed" && exit 1)|} dune_path;
+        Printf.sprintf {|%s dune build --profile=release --only-packages $(cat /tmp/packages-for-dune)|} dune_path
       ]])
 
 let run_job ~cap ~conf ~pool ~debug ~stderr ~base_obuilder ~extra_repos ~switch ~num logdir pkg =


### PR DESCRIPTION
To prioritize bug fixing in dune pkg, I would really like to know when a failure is a likely issue in dune (= package isn't installable, even though it's believed to work when installed via opam), versus a missing dependency required by tests/examples/etc.

(I have no idea if this works, I'm sharing the PR early but I have yet to test it locally... my goal is to get a different red or white color depending on the error cause)