### PR TITLE
Use JaneStreet `sexp` instead of `sexpdata`

### DIFF
--- a/server/backend/check.ml
+++ b/server/backend/check.ml
@@ -265,26 +265,18 @@ let prebuild_toolchains ~conf =
         ])
 
 let install_remove_packages =
-  let script = {|import sexpdata
-with open("dune-project", "r") as f:
-    content = [i for i in sexpdata.loads("(" + f.read() + ")") if not i[0] == sexpdata.Symbol("package")]
-    print(sexpdata.dumps(content[0]))
-    for i in content[1:]:
-        print(sexpdata.dumps(i))|}
-  in
   String.concat " && " [
-    "sudo apt-get install -y python3-sexpdata";
-    Printf.sprintf "echo '%s' > /tmp/opam-health-check-remove-package.py" script;
+    "mkdir /tmp/sexp";
+    "cd /tmp/sexp";
+    "opam switch create ./ ocaml-base-compiler.5.2.1 --no-install";
+    "opam install -y sexp";
+    "cd -";
   ]
 
 let remove_packages =
   String.concat " && " [
-    "python3 /tmp/opam-health-check-remove-package.py > dune-project-new";
+    "/tmp/sexp/_opam/bin/sexp change '(try (rewrite (package @X) OHC-DROP))' < dune-project | grep -v OHC-DROP > dune-project-new";
     "mv dune-project-new dune-project";
-    (* remove the python installation after we have used it so packages don't
-       accidentally depend on it without the conf-python3 depext *)
-    "sudo apt-get remove -y python3-sexpdata";
-    "sudo apt-get autoremove -y"
   ]
 
 let run_script ~conf ~extra_repos pkg =

--- a/server/backend/check.ml
+++ b/server/backend/check.ml
@@ -275,7 +275,7 @@ let install_remove_packages =
 
 let remove_packages =
   String.concat " && " [
-    "/tmp/sexp/_opam/bin/sexp change '(try (rewrite (package @X) OHC-DROP))' < dune-project | grep -v OHC-DROP > dune-project-new";
+    "/tmp/sexp/_opam/bin/sexp change '(try (rewrite (package @X) OPAM-HEALTH-CHECK-DROP))' < dune-project | grep -v OPAM-HEALTH-CHECK-DROP > dune-project-new";
     "mv dune-project-new dune-project";
   ]
 


### PR DESCRIPTION
The issue is that `sexpdata` parses numbers, so something like `(dune lang 1.10)` is parsed as floating point and reduced to `(dune lang 1.1)` which turns the dune-file invalid in some cases.

`sexp` is an OCaml tool from Jane Street, unfortunately it doesn't allow matching and deleting, only matching and rewriting so we rewrite using `sexp` and delete using `grep` in an additional step.