### PR TITLE
Move `build-with` to a per-switch option

### DIFF
--- a/client/client.ml
+++ b/client/client.ml
@@ -87,28 +87,33 @@ let set_processes_cmd ~confdir ~conffile =
   let info = Cmd.info "set-processes" in
   Cmd.v info term
 
-let add_ocaml_switch ~confdir ~conffile profilename name switch =
-  send_msg ~profilename ~confdir ~conffile ["add-ocaml-switch";name;switch]
+let add_ocaml_switch ~confdir ~conffile profilename name switch build_with =
+  send_msg ~profilename ~confdir ~conffile ["add-ocaml-switch"; name; switch; build_with]
+
+let build_with_arg =
+  Arg.value & Arg.opt Arg.string "opam" & Arg.info ~docv:"BUILDER" ["build-with"]
 
 let add_ocaml_switch_cmd ~confdir ~conffile =
   let term =
     Term.const (add_ocaml_switch ~confdir ~conffile) $
     (Arg.value & Arg.opt Arg.string "default" & Arg.info ~docv:"PROFILENAME" ["profile"; "p"]) $
     (Arg.required & Arg.pos 0 (Arg.some Arg.string) None & Arg.info ~docv:"NAME" []) $
-    (Arg.required & Arg.pos 1 (Arg.some Arg.string) None & Arg.info ~docv:"SWITCH" [])
+    (Arg.required & Arg.pos 1 (Arg.some Arg.string) None & Arg.info ~docv:"SWITCH" []) $
+    build_with_arg
   in
   let info = Cmd.info "add-ocaml-switch" in
   Cmd.v info term
 
-let set_ocaml_switch ~confdir ~conffile profilename name switch =
-  send_msg ~profilename ~confdir ~conffile ["set-ocaml-switch";name;switch]
+let set_ocaml_switch ~confdir ~conffile profilename name switch build_with =
+  send_msg ~profilename ~confdir ~conffile ["set-ocaml-switch"; name; switch; build_with]
 
 let set_ocaml_switch_cmd ~confdir ~conffile =
   let term =
     Term.const (set_ocaml_switch ~confdir ~conffile) $
     (Arg.value & Arg.opt Arg.string "default" & Arg.info ~docv:"PROFILENAME" ["profile"; "p"]) $
     (Arg.required & Arg.pos 0 (Arg.some Arg.string) None & Arg.info ~docv:"NAME" []) $
-    (Arg.required & Arg.pos 1 (Arg.some Arg.string) None & Arg.info ~docv:"SWITCH" [])
+    (Arg.required & Arg.pos 1 (Arg.some Arg.string) None & Arg.info ~docv:"SWITCH" []) $
+    build_with_arg
   in
   let info = Cmd.info "set-ocaml-switch" in
   Cmd.v info term

--- a/lib/intf.ml
+++ b/lib/intf.ml
@@ -48,13 +48,6 @@ module Build_with = struct
     | Opam
     | Dune
 
-  let equal a b =
-    match a, b with
-    | Dune, Dune
-    | Opam, Opam -> true
-    | Dune, Opam
-    | Opam, Dune -> false
-
   let compare a b =
     match a, b with
     | Opam, Dune -> -1
@@ -85,9 +78,9 @@ module Switch = struct
     | Build_with.Dune -> true
     | Build_with.Opam -> false
 
-  let equal {name; build_with; _} x =
-    Compiler.equal name x.name &&
-    Build_with.equal build_with x.build_with
+  let equal {name; _} x =
+    (* equality of switches is just equality of their names *)
+    Compiler.equal name x.name
 
   let compare {name; build_with; _} x =
     match Compiler.compare name x.name with

--- a/lib/intf.ml
+++ b/lib/intf.ml
@@ -43,17 +43,56 @@ module Compiler = struct
   let compare (Comp x) (Comp y) = OpamVersionCompare.compare x y
 end
 
+module Build_with = struct
+  type t =
+    | Opam
+    | Dune
+
+  let equal a b =
+    match a, b with
+    | Dune, Dune
+    | Opam, Opam -> true
+    | Dune, Opam
+    | Opam, Dune -> false
+
+  let compare a b =
+    match a, b with
+    | Opam, Dune -> -1
+    | Dune, Dune
+    | Opam, Opam -> 0
+    | Dune, Opam -> 1
+end
+
+
 (* TODO: Exchange the name with the Compiler module *)
 module Switch = struct
-  type t = Switch of Compiler.t * string
+  type t = {
+    name: Compiler.t;
+    switch: string;
+    build_with: Build_with.t;
+  }
 
-  let create ~name ~switch = Switch (Compiler.from_string name, switch)
+  let create ~name ~switch ~build_with =
+    let name = Compiler.from_string name in
+    { name; switch; build_with; }
 
-  let name (Switch (x, _)) = x
-  let switch (Switch (_, x)) = x
+  let name {name; _} = name
+  let switch {switch; _} = switch
+  let build_with {build_with; _} = build_with
 
-  let equal (Switch (x, _)) (Switch (y, _)) = Compiler.equal x y
-  let compare (Switch (x, _)) (Switch (y, _)) = Compiler.compare x y
+  let with_dune {build_with; _} =
+    match build_with with
+    | Build_with.Dune -> true
+    | Build_with.Opam -> false
+
+  let equal {name; build_with; _} x =
+    Compiler.equal name x.name &&
+    Build_with.equal build_with x.build_with
+
+  let compare {name; build_with; _} x =
+    match Compiler.compare name x.name with
+    | 0 -> Build_with.compare build_with x.build_with
+    | otherwise -> otherwise
 end
 
 module Github = struct

--- a/lib/intf.mli
+++ b/lib/intf.mli
@@ -11,6 +11,12 @@ module State : sig
   val to_pretty_string : t -> string
 end
 
+module Build_with : sig
+  type t =
+    | Opam
+    | Dune
+end
+
 module Compiler : sig
   type t
 
@@ -24,10 +30,14 @@ end
 module Switch : sig
   type t
 
-  val create : name:string -> switch:string -> t
+  val create : name:string -> switch:string -> build_with:Build_with.t -> t
 
   val name : t -> Compiler.t
   val switch : t -> string
+  val build_with : t -> Build_with.t
+
+  (* [true] if the switch is using Dune package management *)
+  val with_dune : t -> bool
 
   val equal : t -> t -> bool
   val compare : t -> t -> int

--- a/lib/server_configfile.mli
+++ b/lib/server_configfile.mli
@@ -1,9 +1,5 @@
 type t
 
-type build_with =
-  | Opam
-  | Dune
-
 val from_workdir : Server_workdirs.t -> t
 
 val name : t -> string
@@ -28,7 +24,6 @@ val platform_image : t -> string
 val ocaml_switches : t -> Intf.Switch.t list option
 val slack_webhooks : t -> Uri.t list
 val job_timeout : t -> float
-val build_with : t -> build_with
 
 val set_auto_run_interval : t -> int -> unit Lwt.t
 val set_processes : t -> int -> unit Lwt.t

--- a/server/backend/admin.ml
+++ b/server/backend/admin.ml
@@ -101,11 +101,11 @@ let admin_action ~on_finished ~conf ~run_trigger workdir body =
         let+ () = Server_configfile.set_ocaml_switches conf switches in
         (fun () -> Lwt.return_none)
     | ["rm-ocaml-switch"; name] ->
-        (* create a dummy switch to be able to use remove *)
-        let build_with = Intf.Build_with.Opam in
-        let switch = Intf.Switch.create ~name ~switch:"(* TODO: remove this shit *)" ~build_with in
+        let to_delete = Intf.Compiler.from_string name in
         let switches = Option.get_or ~default:[] (Server_configfile.ocaml_switches conf) in
-        let switches = List.remove ~eq:Intf.Switch.equal ~key:switch switches in
+        let switches = List.filter (fun switch ->
+          Intf.Compiler.equal (Intf.Switch.name switch) to_delete) switches
+        in
         let+ () = Server_configfile.set_ocaml_switches conf switches in
         (fun () -> Lwt.return_none)
     | "set-slack-webhooks"::webhooks ->

--- a/server/backend/check.ml
+++ b/server/backend/check.ml
@@ -345,10 +345,7 @@ let run_job ~cap ~conf ~pool ~debug ~stderr ~base_obuilder ~extra_repos ~switch 
     let logfile = Server_workdirs.tmplogfile ~pkg ~switch:switch_name logdir in
     let* v =
       Lwt_io.with_file ~flags:Unix.[O_WRONLY; O_CREAT; O_TRUNC] ~perm:0o640 ~mode:Lwt_io.Output (Fpath.to_string logfile) (fun stdout ->
-        let with_dune = match Intf.Switch.build_with switch with
-        | Intf.Build_with.Dune -> true
-        | Intf.Build_with.Opam -> false
-        in
+        let with_dune = Intf.Switch.with_dune switch in
         ocluster_build ~cap ~conf ~with_dune ~debug ~base_obuilder ~stdout ~stderr (run_script ~conf ~switch ~extra_repos pkg))
     in
     match v with

--- a/server/backend/check.ml
+++ b/server/backend/check.ml
@@ -2,7 +2,7 @@ open Lwt.Syntax
 
 let fmt = Printf.sprintf
 
-let cache ~stderr ~conf =
+let cache ~stderr ~conf ~with_dune =
   let os = Server_configfile.platform_os conf in
   let opam_cache = match os with
     | "freebsd"
@@ -17,13 +17,13 @@ let cache ~stderr ~conf =
   in
   let+ dune_cache =
     let enable = Some (Obuilder_spec.Cache.v "opam-dune-cache" ~target:"/home/opam/.cache/dune") in
-    match (Server_configfile.enable_dune_cache conf, Server_configfile.build_with conf) with
+    match (Server_configfile.enable_dune_cache conf, with_dune) with
     | true, _ -> Lwt.return enable
-    | false, Server_configfile.Dune ->
+    | false, true ->
       let+ () = Lwt_io.fprintf stderr
         "Cache disabled but building with Dune, automatically enabling. Set `enable-dune-cache` to `true` to silence this warning.\n" in
       enable
-    | false, Server_configfile.Opam -> Lwt.return None
+    | false, false -> Lwt.return None
   in
   List.filter_map (fun x -> x) [opam_cache; brew_cache; dune_cache]
 
@@ -32,8 +32,8 @@ let network = ["host"]
 let obuilder_to_string spec =
   Sexplib0.Sexp.to_string_mach (Obuilder_spec.sexp_of_t spec)
 
-let ocluster_build ~cap ~conf ~base_obuilder ~debug ~stdout ~stderr commands =
-  let* cache = cache ~stderr ~conf in
+let ocluster_build ~cap ~conf ~with_dune ~base_obuilder ~debug ~stdout ~stderr commands =
+  let* cache = cache ~stderr ~conf ~with_dune in
   let scripts = ListLabels.map commands ~f:(fun command ->
     Obuilder_spec.run ~cache ~network "%s" command)
   in
@@ -113,7 +113,7 @@ let exec_out ~fexec ~fout =
   let+ r = proc in
   r, res
 
-let ocluster_build_str ~important ~debug ~cap ~conf ~base_obuilder ~stderr ~default c =
+let ocluster_build_str ~important ~debug ~cap ~conf ~with_dune ~base_obuilder ~stderr ~default c =
   let rec aux ~stdin =
     let* line = Lwt_io.read_line_opt stdin in
     match line with
@@ -135,7 +135,7 @@ let ocluster_build_str ~important ~debug ~cap ~conf ~base_obuilder ~stderr ~defa
     | None -> Lwt.return_nil
   in
   let* v = exec_out ~fout:aux ~fexec:(fun ~stdout ->
-      ocluster_build ~cap ~conf ~debug ~base_obuilder ~stdout ~stderr ["echo @@@OUTPUT && "^c^" && echo @@@OUTPUT"])
+      ocluster_build ~cap ~conf ~with_dune ~debug ~base_obuilder ~stdout ~stderr ["echo @@@OUTPUT && "^c^" && echo @@@OUTPUT"])
   in
   match v with
   | (Ok (), r) ->
@@ -179,12 +179,12 @@ let failure_kind_dune logfile =
     in
     lookup `Other
 
-let failure_kind conf ~pkg logfile =
-  match Server_configfile.build_with conf with
-  | Server_configfile.Opam ->
+let failure_kind conf ~switch ~pkg logfile =
+  match Intf.Switch.build_with switch with
+  | Intf.Build_with.Opam ->
       let timeout = Server_configfile.job_timeout conf in
       failure_kind_opam ~timeout ~pkg logfile
-  | Server_configfile.Dune -> failure_kind_dune logfile
+  | Intf.Build_with.Dune -> failure_kind_dune logfile
 
 let with_test pkg = {|
 if [ $res = 0 ]; then
@@ -279,9 +279,9 @@ let remove_packages =
     "mv dune-project-new dune-project";
   ]
 
-let run_script ~conf ~extra_repos pkg =
-  match Server_configfile.build_with conf with
-  | Server_configfile.Opam ->
+let run_script ~conf ~switch ~extra_repos pkg =
+  match Intf.Switch.build_with switch with
+  | Intf.Build_with.Opam ->
       let build = Printf.sprintf {|opam remove -y %s
 opam install -vy %s
 res=$?
@@ -294,7 +294,7 @@ fi |} pkg pkg pkg (Server_configfile.platform_distribution conf)
       in
       let trailer = {|exit $res|} in
       [String.concat "\n" [build; with_test ~conf pkg; with_lower_bound ~conf pkg; trailer]]
-  | Server_configfile.Dune -> (
+  | Intf.Build_with.Dune -> (
     let pkg_name = match Astring.String.cut ~sep:"." pkg with
       | Some (name, _version) -> name
       | None -> Fmt.failwith "Invalid package format, could not generate commands"
@@ -341,33 +341,37 @@ fi |} pkg pkg pkg (Server_configfile.platform_distribution conf)
 let run_job ~cap ~conf ~pool ~debug ~stderr ~base_obuilder ~extra_repos ~switch ~num logdir pkg =
   Lwt_pool.use pool begin fun () ->
     let* () = Lwt_io.write_line stderr ("["^num^"] Checking "^pkg^" on "^Intf.Switch.switch switch^"…") in
-    let switch = Intf.Switch.name switch in
-    let logfile = Server_workdirs.tmplogfile ~pkg ~switch logdir in
+    let switch_name = Intf.Switch.name switch in
+    let logfile = Server_workdirs.tmplogfile ~pkg ~switch:switch_name logdir in
     let* v =
       Lwt_io.with_file ~flags:Unix.[O_WRONLY; O_CREAT; O_TRUNC] ~perm:0o640 ~mode:Lwt_io.Output (Fpath.to_string logfile) (fun stdout ->
-        ocluster_build ~cap ~conf ~debug ~base_obuilder ~stdout ~stderr (run_script ~conf ~extra_repos pkg))
+        let with_dune = match Intf.Switch.build_with switch with
+        | Intf.Build_with.Dune -> true
+        | Intf.Build_with.Opam -> false
+        in
+        ocluster_build ~cap ~conf ~with_dune ~debug ~base_obuilder ~stdout ~stderr (run_script ~conf ~switch ~extra_repos pkg))
     in
     match v with
     | Ok () ->
         Prometheus.Counter.inc_one Metrics.jobs_ok;
         let* () = Lwt_io.write_line stderr ("["^num^"] succeeded.") in
-        Lwt_unix.rename (Fpath.to_string logfile) (Fpath.to_string (Server_workdirs.tmpgoodlog ~pkg ~switch logdir))
+        Lwt_unix.rename (Fpath.to_string logfile) (Fpath.to_string (Server_workdirs.tmpgoodlog ~pkg ~switch:switch_name logdir))
     | Error () ->
         Prometheus.Counter.inc_one Metrics.jobs_error;
-        let* v = failure_kind conf ~pkg logfile in
+        let* v = failure_kind conf ~switch ~pkg logfile in
         begin match v with
         | `Partial ->
             let* () = Lwt_io.write_line stderr ("["^num^"] finished with a partial failure.") in
-            Lwt_unix.rename (Fpath.to_string logfile) (Fpath.to_string (Server_workdirs.tmppartiallog ~pkg ~switch logdir))
+            Lwt_unix.rename (Fpath.to_string logfile) (Fpath.to_string (Server_workdirs.tmppartiallog ~pkg ~switch:switch_name logdir))
         | `Failure ->
             let* () = Lwt_io.write_line stderr ("["^num^"] failed.") in
-            Lwt_unix.rename (Fpath.to_string logfile) (Fpath.to_string (Server_workdirs.tmpbadlog ~pkg ~switch logdir))
+            Lwt_unix.rename (Fpath.to_string logfile) (Fpath.to_string (Server_workdirs.tmpbadlog ~pkg ~switch:switch_name logdir))
         | `NotAvailable ->
             let* () = Lwt_io.write_line stderr ("["^num^"] finished with not available.") in
-            Lwt_unix.rename (Fpath.to_string logfile) (Fpath.to_string (Server_workdirs.tmpnotavailablelog ~pkg ~switch logdir))
+            Lwt_unix.rename (Fpath.to_string logfile) (Fpath.to_string (Server_workdirs.tmpnotavailablelog ~pkg ~switch:switch_name logdir))
         | `Other | `AcceptFailures | `Timeout ->
             let* () = Lwt_io.write_line stderr ("["^num^"] finished with an internal failure.") in
-            Lwt_unix.rename (Fpath.to_string logfile) (Fpath.to_string (Server_workdirs.tmpinternalfailurelog ~pkg ~switch logdir))
+            Lwt_unix.rename (Fpath.to_string logfile) (Fpath.to_string (Server_workdirs.tmpinternalfailurelog ~pkg ~switch:switch_name logdir))
         end
   end
 
@@ -461,9 +465,10 @@ let get_obuilder ~conf ~cache ~opam_repo ~opam_repo_commit ~extra_repos switch =
   end
 
 let get_pkgs ~debug ~cap ~conf ~stderr (switch, base_obuilder) =
+  let with_dune = Intf.Switch.with_dune switch in
   let switch = Intf.Compiler.to_string (Intf.Switch.name switch) in
   let* () = Lwt_io.write_line stderr ("Getting packages list for "^switch^"… (this may take an hour or two)") in
-  let* pkgs = ocluster_build_str ~important:true ~debug ~cap ~conf ~base_obuilder ~stderr ~default:None (Server_configfile.list_command conf) in
+  let* pkgs = ocluster_build_str ~important:true ~debug ~cap ~conf ~with_dune ~base_obuilder ~stderr ~default:None (Server_configfile.list_command conf) in
   let pkgs = List.filter begin fun pkg ->
     Oca_lib.is_valid_filename pkg &&
     match Intf.Pkg.name (Intf.Pkg.create ~full_name:pkg ~instances:[] ~opam:OpamFile.OPAM.empty ~revdeps:0) with (* TODO: Remove this horror *)
@@ -508,9 +513,9 @@ let revdeps_script pkg =
   {|opam list --color=never -s --recursive --depopts --depends-on |}^pkg^{| && \
     opam list --color=never -s --with-test --with-doc --depopts --depends-on |}^pkg
 
-let get_metadata ~debug ~jobs ~cap ~conf ~pool ~stderr logdir (_, base_obuilder) pkgs =
+let get_metadata ~debug ~jobs ~cap ~conf ~with_dune ~pool ~stderr logdir (_, base_obuilder) pkgs =
   let get_revdeps ~base_obuilder ~pkgname ~pkg ~logdir =
-    let* revdeps = ocluster_build_str ~important:false ~debug ~cap ~conf ~base_obuilder ~stderr ~default:(Some []) (revdeps_script pkg) in
+    let* revdeps = ocluster_build_str ~important:false ~debug ~cap ~conf ~with_dune ~base_obuilder ~stderr ~default:(Some []) (revdeps_script pkg) in
     let module Set = Set.Make(String) in
     let revdeps = Set.of_list revdeps in
     let revdeps = Set.remove pkgname revdeps in (* https://github.com/ocaml/opam/issues/4446 *)
@@ -520,7 +525,7 @@ let get_metadata ~debug ~jobs ~cap ~conf ~pool ~stderr logdir (_, base_obuilder)
   in
   let get_latest_metadata ~base_obuilder ~pkgname ~logdir = (* TODO: Get this locally by merging all the repository and parsing the opam files using opam-core *)
     let* opam =
-      ocluster_build_str ~important:false ~debug ~cap ~conf ~base_obuilder ~stderr ~default:(Some [])
+      ocluster_build_str ~important:false ~debug ~cap ~conf ~with_dune ~base_obuilder ~stderr ~default:(Some [])
         ("opam show --raw "^Filename.quote pkgname)
     in
     Lwt_io.with_file ~mode:Lwt_io.output (Fpath.to_string (Server_workdirs.tmpopamfile ~pkg:pkgname logdir)) (fun c ->
@@ -718,7 +723,8 @@ let run ~debug ~cap_file ~on_finished ~conf oca_cache workdir =
         let* cap = get_cap ~stderr ~cap_file in
         let* opam_repo, opam_repo_commit = get_commit_hash_default conf in
         let* extra_repos = get_commit_hash_extra_repos conf in
-        let* cache = cache ~stderr ~conf in
+        let with_dune = List.exists Intf.Switch.with_dune switches in
+        let* cache = cache ~stderr ~conf ~with_dune in
         let switches' = switches in
         let switches = List.map (fun switch -> (switch, get_obuilder ~conf ~cache ~opam_repo ~opam_repo_commit ~extra_repos switch)) switches in
         begin match switches with
@@ -734,7 +740,7 @@ let run ~debug ~cap_file ~on_finished ~conf oca_cache workdir =
             Prometheus.Gauge.set Metrics.number_of_packages (float_of_int (Pkg_set.cardinal pkgs));
             let* () = Oca_lib.timer_log timer stderr "Initialization" in
             let (_, jobs) = run_jobs ~cap ~conf ~debug ~pool ~stderr ~extra_repos new_logdir switches pkgs in
-            let (_, jobs) = get_metadata ~debug ~jobs ~cap ~conf ~pool ~stderr new_logdir switch pkgs in
+            let (_, jobs) = get_metadata ~debug ~jobs ~cap ~conf ~with_dune ~pool ~stderr new_logdir switch pkgs in
             let* () = Lwt.join jobs in
             let* () = Oca_lib.timer_log timer stderr "Operation" in
             let* () = Lwt_io.write_line stderr "Finishing up…" in


### PR DESCRIPTION
As this was requested by a few people including @samoht I spent some time moving the `build-with` option to the OCaml switch list. That means that it is possible to configure a switch like `5.3` to build with opam and `5.3+dune` that will build the packages with Dune.

It extends the client and admin protocol a little to be able to pass the `build-with` option around.