### PR TITLE
Use `--release` instead of `--profile=release`

### DIFF
--- a/server/backend/check.ml
+++ b/server/backend/check.ml
@@ -336,7 +336,7 @@ fi |} pkg pkg pkg (Server_configfile.platform_distribution conf)
         (* avoid invalid dependency hash errors by removing the hash *)
         "grep -v dependency_hash dune.lock/lock.dune > /tmp/lock.dune";
         "mv /tmp/lock.dune dune.lock/lock.dune";
-        Printf.sprintf {|%s dune build --profile=release --only-packages $(cat /tmp/packages-for-dune) || (echo "opam-health-check: Build failed" && exit 1)|} dune_path
+        Printf.sprintf {|%s dune build --release --only-packages $(cat /tmp/packages-for-dune) || (echo "opam-health-check: Build failed" && exit 1)|} dune_path
       ]])
 
 let run_job ~cap ~conf ~pool ~debug ~stderr ~base_obuilder ~extra_repos ~switch ~num logdir pkg =


### PR DESCRIPTION
This change avoids tests being built if they're not used. It should fix a lot of Jane Street packages.

We added support for lockfiles and `--release` mode recently and it is supported by the preview binaries so we should be able to use that in the health check now.