### PR TITLE
Compiler name switcheroo

### DIFF
--- a/lib/intf.ml
+++ b/lib/intf.ml
@@ -78,10 +78,6 @@ module Switch = struct
     | Build_with.Dune -> true
     | Build_with.Opam -> false
 
-  let equal {compiler; _} x =
-    (* equality of switches is just equality of their compilers *)
-    Compiler.equal compiler x.compiler
-
   let compare {compiler; build_with; _} x =
     match Compiler.compare compiler x.compiler with
     | 0 -> Build_with.compare build_with x.build_with

--- a/lib/intf.ml
+++ b/lib/intf.ml
@@ -78,9 +78,11 @@ module Switch = struct
     | Build_with.Dune -> true
     | Build_with.Opam -> false
 
-  let compare {compiler; build_with; _} x =
+  let compare {compiler; build_with; name} x =
     match Compiler.compare compiler x.compiler with
-    | 0 -> Build_with.compare build_with x.build_with
+    | 0 -> (match String.compare name x.name with 
+      | 0 -> Build_with.compare build_with x.build_with
+      | otherwise -> otherwise)
     | otherwise -> otherwise
 end
 

--- a/lib/intf.ml
+++ b/lib/intf.ml
@@ -38,9 +38,12 @@ module Compiler = struct
       failwith "Forbidden switch name";
     Comp x
 
+
   let to_string (Comp x) = x
   let equal (Comp x) (Comp y) = OpamVersionCompare.equal x y
   let compare (Comp x) (Comp y) = OpamVersionCompare.compare x y
+
+  let pp ppf (Comp x) = Format.fprintf ppf "%s" x
 end
 
 module Build_with = struct
@@ -60,17 +63,17 @@ end
 (* TODO: Exchange the name with the Compiler module *)
 module Switch = struct
   type t = {
-    name: Compiler.t;
-    switch: string;
+    compiler: Compiler.t;
+    name: string;
     build_with: Build_with.t;
   }
 
-  let create ~name ~switch ~build_with =
-    let name = Compiler.from_string name in
-    { name; switch; build_with; }
+  let create ~name ~compiler ~build_with =
+    let compiler = Compiler.from_string compiler in
+    { name; compiler; build_with; }
 
   let name {name; _} = name
-  let switch {switch; _} = switch
+  let compiler {compiler; _} = compiler
   let build_with {build_with; _} = build_with
 
   let with_dune {build_with; _} =
@@ -78,12 +81,12 @@ module Switch = struct
     | Build_with.Dune -> true
     | Build_with.Opam -> false
 
-  let equal {name; _} x =
-    (* equality of switches is just equality of their names *)
-    Compiler.equal name x.name
+  let equal {compiler; _} x =
+    (* equality of switches is just equality of their compilers *)
+    Compiler.equal compiler x.compiler
 
-  let compare {name; build_with; _} x =
-    match Compiler.compare name x.name with
+  let compare {compiler; build_with; _} x =
+    match Compiler.compare compiler x.compiler with
     | 0 -> Build_with.compare build_with x.build_with
     | otherwise -> otherwise
 end

--- a/lib/intf.ml
+++ b/lib/intf.ml
@@ -38,7 +38,6 @@ module Compiler = struct
       failwith "Forbidden switch name";
     Comp x
 
-
   let to_string (Comp x) = x
   let equal (Comp x) (Comp y) = OpamVersionCompare.equal x y
   let compare (Comp x) (Comp y) = OpamVersionCompare.compare x y
@@ -59,8 +58,6 @@ module Build_with = struct
     | Dune, Opam -> 1
 end
 
-
-(* TODO: Exchange the name with the Compiler module *)
 module Switch = struct
   type t = {
     compiler: Compiler.t;

--- a/lib/intf.mli
+++ b/lib/intf.mli
@@ -25,15 +25,17 @@ module Compiler : sig
 
   val equal : t -> t -> bool
   val compare : t -> t -> int
+
+  val pp : Format.formatter -> t -> unit
 end
 
 module Switch : sig
   type t
 
-  val create : name:string -> switch:string -> build_with:Build_with.t -> t
+  val create : name:string -> compiler:string -> build_with:Build_with.t -> t
 
-  val name : t -> Compiler.t
-  val switch : t -> string
+  val name : t -> string
+  val compiler : t -> Compiler.t
   val build_with : t -> Build_with.t
 
   (* [true] if the switch is using Dune package management *)

--- a/lib/intf.mli
+++ b/lib/intf.mli
@@ -41,7 +41,6 @@ module Switch : sig
   (* [true] if the switch is using Dune package management *)
   val with_dune : t -> bool
 
-  val equal : t -> t -> bool
   val compare : t -> t -> int
 end
 

--- a/lib/server_configfile.ml
+++ b/lib/server_configfile.ml
@@ -73,9 +73,9 @@ let get_comp_str = function
   | _ -> failwith "string expected"
 
 let get_comp = function
-  | `O [name, `O [ ("switch", `String switch); ("build-with", build_with)] ] ->
+  | `O [name, `O [ ("switch", `String compiler); ("build-with", build_with)] ] ->
       let build_with = build_with_of_yaml_exn build_with in
-      Intf.Switch.create ~name ~switch ~build_with
+      Intf.Switch.create ~name ~compiler ~build_with
   | _ ->
       failwith "key and value expected"
 
@@ -172,8 +172,8 @@ let yaml_of_extra_repositories l =
 
 let yaml_of_ocaml_switches l =
   `A (List.map (fun s ->
-    `O [Intf.(Compiler.to_string (Switch.name s)),
-        `O ["switch", `String (Intf.Switch.switch s); "build-with", yaml_of_build_with (Intf.Switch.build_with s)]]) l)
+    `O [Intf.Switch.name s,
+        `O ["switch", `String (s |> Intf.Switch.compiler |> Intf.Compiler.to_string); "build-with", yaml_of_build_with (Intf.Switch.build_with s)]]) l)
 
 let yaml_of_slack_webhooks l =
   `A (List.map (fun s -> `String (Uri.to_string s)) l)

--- a/lib/server_configfile.ml
+++ b/lib/server_configfile.ml
@@ -97,7 +97,7 @@ let check_is_docker_compatible name =
   if not (String.for_all Oca_lib.char_is_docker_compatible name) then
     failwith "name field has to contain only alphanumerical characters and '.'"
 
-let ensure_no_duplicate_switches switches =
+let assert_unique_switch_names switches =
   let module Names = Set.Make (String) in
   let init = Names.empty in
   ListLabels.fold_left ~init ~f:(fun names switch ->
@@ -160,7 +160,7 @@ let set_config conf = function
       ) platform
   | "ocaml-switches" as field, `A switches ->
       let switches = List.map get_comp switches in
-      ensure_no_duplicate_switches switches;
+      assert_unique_switch_names switches;
       set_field ~field (fun () -> conf.ocaml_switches <- Some switches) conf.ocaml_switches
   | "slack-webhooks" as field, `A webhooks ->
       let webhooks = List.map get_uri webhooks in

--- a/lib/server_workdirs.ml
+++ b/lib/server_workdirs.ml
@@ -111,12 +111,13 @@ let logdir_search ~switch ~regexp = function
 let tmpdir (Logdir (_, _, _, workdir, _) as logdir) = base_tmpdir workdir/get_logdir_name logdir
 
 let tmplogdir logdir = tmpdir logdir/"logs"
-let tmpswitchlogdir ~switch logdir = tmplogdir logdir/Intf.Compiler.to_string switch
+let tmpswitchlogdir ~name logdir = tmplogdir logdir/name
 
-let logdir_move ~switches (Logdir (ty, _, _, workdir, _) as logdir) = match ty with
+let logdir_move ~names (Logdir (ty, _, _, workdir, _) as logdir) =
+  match ty with
   | Compressed ->
       let cwd = tmplogdir logdir in
-      let directories = List.map Intf.Compiler.to_string switches in
+      let directories = names in
       let archive = base_logdir workdir/get_logdir_name logdir+"txz" in
       let* () = Oca_lib.compress_tpxz_archive ~cwd ~directories archive in
       Oca_lib.rm_rf cwd
@@ -128,18 +129,18 @@ let logdir_move ~switches (Logdir (ty, _, _, workdir, _) as logdir) = match ty w
 let ilogdir workdir = workdir/"ilogs"
 let new_ilogfile ~start_time workdir = ilogdir workdir/Printf.sprintf "%.0f" start_time
 
-let tmpgooddir ~switch logdir = tmpswitchlogdir ~switch logdir/"good"
-let tmppartialdir ~switch logdir = tmpswitchlogdir ~switch logdir/"partial"
-let tmpbaddir ~switch logdir = tmpswitchlogdir ~switch logdir/"bad"
-let tmpnotavailabledir ~switch logdir = tmpswitchlogdir ~switch logdir/"not-available"
-let tmpinternalfailuredir ~switch logdir = tmpswitchlogdir ~switch logdir/"internal-failure"
-let tmplogfile ~pkg ~switch logdir = tmpswitchlogdir ~switch logdir/pkg
+let tmpgooddir ~name logdir = tmpswitchlogdir ~name logdir/"good"
+let tmppartialdir ~name logdir = tmpswitchlogdir ~name logdir/"partial"
+let tmpbaddir ~name logdir = tmpswitchlogdir ~name logdir/"bad"
+let tmpnotavailabledir ~name logdir = tmpswitchlogdir ~name logdir/"not-available"
+let tmpinternalfailuredir ~name logdir = tmpswitchlogdir ~name logdir/"internal-failure"
+let tmplogfile ~pkg ~name logdir = tmpswitchlogdir ~name logdir/pkg
 
-let tmpgoodlog ~pkg ~switch logdir = tmpgooddir ~switch logdir/pkg
-let tmppartiallog ~pkg ~switch logdir = tmppartialdir ~switch logdir/pkg
-let tmpbadlog ~pkg ~switch logdir = tmpbaddir ~switch logdir/pkg
-let tmpnotavailablelog ~pkg ~switch logdir = tmpnotavailabledir ~switch logdir/pkg
-let tmpinternalfailurelog ~pkg ~switch logdir = tmpinternalfailuredir ~switch logdir/pkg
+let tmpgoodlog ~pkg ~name logdir = tmpgooddir ~name logdir/pkg
+let tmppartiallog ~pkg ~name logdir = tmppartialdir ~name logdir/pkg
+let tmpbadlog ~pkg ~name logdir = tmpbaddir ~name logdir/pkg
+let tmpnotavailablelog ~pkg ~name logdir = tmpnotavailabledir ~name logdir/pkg
+let tmpinternalfailurelog ~pkg ~name logdir = tmpinternalfailuredir ~name logdir/pkg
 
 let metadatadir workdir = workdir/"metadata"
 let opamsdir workdir = metadatadir workdir/"opams"
@@ -163,12 +164,12 @@ let init_base workdir =
   Oca_lib.mkdir_p (revdepsdir workdir)
 
 let init_base_job ~switch logdir =
-  let switch = Intf.Switch.name switch in
-  let* () = Oca_lib.mkdir_p (tmpgooddir ~switch logdir) in
-  let* () = Oca_lib.mkdir_p (tmppartialdir ~switch logdir) in
-  let* () = Oca_lib.mkdir_p (tmpbaddir ~switch logdir) in
-  let* () = Oca_lib.mkdir_p (tmpnotavailabledir ~switch logdir) in
-  Oca_lib.mkdir_p (tmpinternalfailuredir ~switch logdir)
+  let name = Intf.Switch.name switch in
+  let* () = Oca_lib.mkdir_p (tmpgooddir ~name logdir) in
+  let* () = Oca_lib.mkdir_p (tmppartialdir ~name logdir) in
+  let* () = Oca_lib.mkdir_p (tmpbaddir ~name logdir) in
+  let* () = Oca_lib.mkdir_p (tmpnotavailabledir ~name logdir) in
+  Oca_lib.mkdir_p (tmpinternalfailuredir ~name logdir)
 
 let init_base_jobs ~switches logdir =
   let* () = Oca_lib.mkdir_p (tmplogdir logdir) in

--- a/lib/server_workdirs.mli
+++ b/lib/server_workdirs.mli
@@ -22,7 +22,7 @@ val notavailablefiles : switch:Intf.Compiler.t -> logdir -> string list
 val internalfailurefiles : switch:Intf.Compiler.t -> logdir -> string list
 val logdir_get_content : comp:Intf.Compiler.t -> state:Intf.State.t -> pkg:string -> logdir -> string Lwt.t
 val logdir_get_compilers : logdir -> Intf.Compiler.t list
-val logdir_move : switches:Intf.Compiler.t list -> logdir -> unit Lwt.t
+val logdir_move : names:string list -> logdir -> unit Lwt.t
 val logdir_search : switch:string -> regexp:string -> logdir -> string list Lwt.t
 
 val ilogdir : t -> Fpath.t
@@ -31,13 +31,13 @@ val new_ilogfile : start_time:float -> t -> Fpath.t
 val tmpdir : logdir -> Fpath.t
 
 val tmplogdir : logdir -> Fpath.t
-val tmplogfile : pkg:string -> switch:Intf.Compiler.t -> logdir -> Fpath.t
+val tmplogfile : pkg:string -> name:string -> logdir -> Fpath.t
 
-val tmpgoodlog : pkg:string -> switch:Intf.Compiler.t -> logdir -> Fpath.t
-val tmppartiallog : pkg:string -> switch:Intf.Compiler.t -> logdir -> Fpath.t
-val tmpbadlog : pkg:string -> switch:Intf.Compiler.t -> logdir -> Fpath.t
-val tmpnotavailablelog : pkg:string -> switch:Intf.Compiler.t -> logdir -> Fpath.t
-val tmpinternalfailurelog : pkg:string -> switch:Intf.Compiler.t -> logdir -> Fpath.t
+val tmpgoodlog : pkg:string -> name:string -> logdir -> Fpath.t
+val tmppartiallog : pkg:string -> name:string -> logdir -> Fpath.t
+val tmpbadlog : pkg:string -> name:string -> logdir -> Fpath.t
+val tmpnotavailablelog : pkg:string -> name:string -> logdir -> Fpath.t
+val tmpinternalfailurelog : pkg:string -> name:string -> logdir -> Fpath.t
 
 val metadatadir : t -> Fpath.t
 val opamsdir : t -> Fpath.t

--- a/server/backend/admin.ml
+++ b/server/backend/admin.ml
@@ -82,9 +82,9 @@ let admin_action ~on_finished ~conf ~run_trigger workdir body =
         else
           let+ () = Server_configfile.set_processes conf i in
           (fun () -> Lwt.return_none)
-    | ["add-ocaml-switch"; name; switch; build_with] ->
+    | ["add-ocaml-switch"; name; compiler; build_with] ->
         let build_with = build_with_of_string_exn build_with in
-        let switch = Intf.Switch.create ~name ~switch ~build_with in
+        let switch = Intf.Switch.create ~name ~compiler ~build_with in
         let switches = Option.get_or ~default:[] (Server_configfile.ocaml_switches conf) in
         if List.mem ~eq:Intf.Switch.equal switch switches then
           Lwt.fail (Failure "Cannot have duplicate switches names.")
@@ -92,9 +92,9 @@ let admin_action ~on_finished ~conf ~run_trigger workdir body =
           let switches = List.sort Intf.Switch.compare (switch :: switches) in
           let+ () = Server_configfile.set_ocaml_switches conf switches in
           (fun () -> Lwt.return_none)
-    | ["set-ocaml-switch"; name; switch; build_with] ->
+    | ["set-ocaml-switch"; name; compiler; build_with] ->
         let build_with = build_with_of_string_exn build_with in
-        let switch = Intf.Switch.create ~name ~switch ~build_with in
+        let switch = Intf.Switch.create ~name ~compiler ~build_with in
         let switches = Option.get_or ~default:[] (Server_configfile.ocaml_switches conf) in
         let idx, _ = Option.get_exn_or "can't find switch name" (List.find_idx (Intf.Switch.equal switch) switches) in
         let switches = List.set_at_idx idx switch switches in
@@ -104,7 +104,7 @@ let admin_action ~on_finished ~conf ~run_trigger workdir body =
         let to_delete = Intf.Compiler.from_string name in
         let switches = Option.get_or ~default:[] (Server_configfile.ocaml_switches conf) in
         let switches = List.filter (fun switch ->
-          Intf.Compiler.equal (Intf.Switch.name switch) to_delete) switches
+          Intf.Compiler.equal (Intf.Switch.compiler switch) to_delete) switches
         in
         let+ () = Server_configfile.set_ocaml_switches conf switches in
         (fun () -> Lwt.return_none)

--- a/server/backend/admin.ml
+++ b/server/backend/admin.ml
@@ -86,7 +86,8 @@ let admin_action ~on_finished ~conf ~run_trigger workdir body =
         let build_with = build_with_of_string_exn build_with in
         let switch = Intf.Switch.create ~name ~compiler ~build_with in
         let switches = Option.get_or ~default:[] (Server_configfile.ocaml_switches conf) in
-        if List.mem ~eq:Intf.Switch.equal switch switches then
+        let switch_names = List.map Intf.Switch.name switches in
+        if List.mem ~eq:String.equal name switch_names then
           Lwt.fail (Failure "Cannot have duplicate switches names.")
         else
           let switches = List.sort Intf.Switch.compare (switch :: switches) in
@@ -96,7 +97,7 @@ let admin_action ~on_finished ~conf ~run_trigger workdir body =
         let build_with = build_with_of_string_exn build_with in
         let switch = Intf.Switch.create ~name ~compiler ~build_with in
         let switches = Option.get_or ~default:[] (Server_configfile.ocaml_switches conf) in
-        let idx, _ = Option.get_exn_or "can't find switch name" (List.find_idx (Intf.Switch.equal switch) switches) in
+        let idx, _ = Option.get_exn_or "can't find switch name" (List.find_idx (fun sw -> String.equal (Intf.Switch.name sw) name) switches) in
         let switches = List.set_at_idx idx switch switches in
         let+ () = Server_configfile.set_ocaml_switches conf switches in
         (fun () -> Lwt.return_none)

--- a/server/backend/check.ml
+++ b/server/backend/check.ml
@@ -244,12 +244,13 @@ let set_up_workspace ~extra_repos =
 
 let dune_path = "PATH=$HOME/.local/bin:$PATH"
 
-let set_up_project_using ~switch =
+let set_up_project_using ~compiler =
+  let version = Intf.Compiler.to_string compiler in
   let dune_project = Printf.sprintf {|(lang dune 3.17)
 (package
   (name dummy)
   (allow_empty true)
-  (depends (ocaml (= %s))))|} switch in
+  (depends (ocaml (= %s))))|} version in
   Printf.sprintf {|echo '%s' > dune-project|} dune_project
 
 let prebuild_toolchains ~conf =
@@ -259,10 +260,10 @@ let prebuild_toolchains ~conf =
     switches
     |> ListLabels.filter ~f:Intf.Switch.with_dune
     |> ListLabels.map ~f:(fun switch ->
-        let switch = Intf.Switch.switch switch in
+        let compiler = Intf.Switch.compiler switch in
         String.concat " && " [
           "PLACE=$(mktemp -d) && cd $PLACE";
-          set_up_project_using ~switch;
+          set_up_project_using ~compiler;
           Printf.sprintf {|%s dune pkg lock|} dune_path;
           Printf.sprintf {|%s dune build|} dune_path;
         ])
@@ -355,9 +356,9 @@ fi |} pkg pkg pkg (Server_configfile.platform_distribution conf)
 
 let run_job ~cap ~conf ~pool ~debug ~stderr ~base_obuilder ~extra_repos ~switch ~num logdir pkg =
   Lwt_pool.use pool begin fun () ->
-    let* () = Lwt_io.write_line stderr ("["^num^"] Checking "^pkg^" on "^Intf.Switch.switch switch^"…") in
-    let switch_name = Intf.Switch.name switch in
-    let logfile = Server_workdirs.tmplogfile ~pkg ~switch:switch_name logdir in
+    let* () = Lwt_io.write_line stderr ("["^num^"] Checking "^pkg^" on "^Intf.Switch.name switch^"…") in
+    let name = Intf.Switch.name switch in
+    let logfile = Server_workdirs.tmplogfile ~pkg ~name logdir in
     let* v =
       Lwt_io.with_file ~flags:Unix.[O_WRONLY; O_CREAT; O_TRUNC] ~perm:0o640 ~mode:Lwt_io.Output (Fpath.to_string logfile) (fun stdout ->
         let with_dune = Intf.Switch.with_dune switch in
@@ -367,23 +368,23 @@ let run_job ~cap ~conf ~pool ~debug ~stderr ~base_obuilder ~extra_repos ~switch 
     | Ok () ->
         Prometheus.Counter.inc_one Metrics.jobs_ok;
         let* () = Lwt_io.write_line stderr ("["^num^"] succeeded.") in
-        Lwt_unix.rename (Fpath.to_string logfile) (Fpath.to_string (Server_workdirs.tmpgoodlog ~pkg ~switch:switch_name logdir))
+        Lwt_unix.rename (Fpath.to_string logfile) (Fpath.to_string (Server_workdirs.tmpgoodlog ~pkg ~name logdir))
     | Error () ->
         Prometheus.Counter.inc_one Metrics.jobs_error;
         let* v = failure_kind conf ~switch ~pkg logfile in
         begin match v with
         | `Partial ->
             let* () = Lwt_io.write_line stderr ("["^num^"] finished with a partial failure.") in
-            Lwt_unix.rename (Fpath.to_string logfile) (Fpath.to_string (Server_workdirs.tmppartiallog ~pkg ~switch:switch_name logdir))
+            Lwt_unix.rename (Fpath.to_string logfile) (Fpath.to_string (Server_workdirs.tmppartiallog ~pkg ~name logdir))
         | `Failure ->
             let* () = Lwt_io.write_line stderr ("["^num^"] failed.") in
-            Lwt_unix.rename (Fpath.to_string logfile) (Fpath.to_string (Server_workdirs.tmpbadlog ~pkg ~switch:switch_name logdir))
+            Lwt_unix.rename (Fpath.to_string logfile) (Fpath.to_string (Server_workdirs.tmpbadlog ~pkg ~name logdir))
         | `NotAvailable ->
             let* () = Lwt_io.write_line stderr ("["^num^"] finished with not available.") in
-            Lwt_unix.rename (Fpath.to_string logfile) (Fpath.to_string (Server_workdirs.tmpnotavailablelog ~pkg ~switch:switch_name logdir))
+            Lwt_unix.rename (Fpath.to_string logfile) (Fpath.to_string (Server_workdirs.tmpnotavailablelog ~pkg ~name logdir))
         | `Other | `AcceptFailures | `Timeout ->
             let* () = Lwt_io.write_line stderr ("["^num^"] finished with an internal failure.") in
-            Lwt_unix.rename (Fpath.to_string logfile) (Fpath.to_string (Server_workdirs.tmpinternalfailurelog ~pkg ~switch:switch_name logdir))
+            Lwt_unix.rename (Fpath.to_string logfile) (Fpath.to_string (Server_workdirs.tmpinternalfailurelog ~pkg ~name logdir))
         end
   end
 
@@ -396,11 +397,11 @@ let () =
 
 let get_obuilder ~conf ~cache ~opam_repo ~opam_repo_commit ~extra_repos switch =
   let extra_repos =
-    let switch = Intf.Switch.name switch in
+    let compiler = Intf.Switch.compiler switch in
     List.filter (fun (repo, _) ->
       match Intf.Repository.for_switches repo with
       | None -> true
-      | Some for_switches -> List.exists (Intf.Compiler.equal switch) for_switches
+      | Some for_switches -> List.exists (Intf.Compiler.equal compiler) for_switches
     ) extra_repos
   in
   let open Obuilder_spec in
@@ -449,12 +450,13 @@ let get_obuilder ~conf ~cache ~opam_repo ~opam_repo_commit ~extra_repos switch =
     ) @ [
       run ~cache ~network "opam switch create --repositories=%sdefault '%s' '%s'"
         (List.fold_left (fun acc (repo, _) -> Intf.Repository.name repo^","^acc) "" extra_repos)
-        (Intf.Compiler.to_string (Intf.Switch.name switch))
-        (Intf.Switch.switch switch);
+        (Intf.Switch.name switch)
+        (Intf.Compiler.to_string (Intf.Switch.compiler switch));
       run ~network "opam update --depexts";
     ] @
     (* TODO: Should this be removed now that it is part of the base docker images? What about macOS? *)
-    (if OpamVersionCompare.compare (Intf.Switch.switch switch) "4.08" < 0 then
+    (* TODO: this is wonky because it assumes the version of the compiler from the switch name which is arbitrary *)
+    (if OpamVersionCompare.compare (Intf.Switch.name switch) "4.08" < 0 then
        [run ~cache ~network "opam install -y ocaml-secondary-compiler"]
        (* NOTE: See https://github.com/ocaml/opam-repository/pull/15404
                 and https://github.com/ocaml/opam-repository/pull/15642 *)
@@ -478,8 +480,9 @@ let get_obuilder ~conf ~cache ~opam_repo ~opam_repo_commit ~extra_repos switch =
 
 let get_pkgs ~debug ~cap ~conf ~stderr (switch, base_obuilder) =
   let with_dune = Intf.Switch.with_dune switch in
-  let switch = Intf.Compiler.to_string (Intf.Switch.name switch) in
-  let* () = Lwt_io.write_line stderr ("Getting packages list for "^switch^"… (this may take an hour or two)") in
+  let compiler = Intf.Switch.compiler switch in
+  let line = Format.asprintf "Getting packages list for %a… (this may take an hour or two)" Intf.Compiler.pp compiler in
+  let* () = Lwt_io.write_line stderr line in
   let* pkgs = ocluster_build_str ~important:true ~debug ~cap ~conf ~with_dune ~base_obuilder ~stderr ~default:None (Server_configfile.list_command conf) in
   let pkgs = List.filter begin fun pkg ->
     Oca_lib.is_valid_filename pkg &&
@@ -507,8 +510,9 @@ let get_pkgs ~debug ~cap ~conf ~stderr (switch, base_obuilder) =
     | "ocaml-options-vanilla" -> false
     | _ -> true
   end pkgs in
-  let nelts = string_of_int (List.length pkgs) in
-  let+ () = Lwt_io.write_line stderr ("Package list for "^switch^" retrieved. "^nelts^" elements to process.") in
+  let nelts = List.length pkgs in
+  let line = Format.asprintf "Package list for %a retrieved. %d elements to process." Intf.Compiler.pp compiler nelts in
+  let+ () = Lwt_io.write_line stderr line in
   pkgs
 
 let with_stderr ~start_time workdir f =
@@ -591,8 +595,8 @@ let move_tmpdirs_to_final ~switches logdir workdir =
   let metadatadir = Server_workdirs.metadatadir workdir in
   let tmpmetadatadir = Server_workdirs.tmpmetadatadir logdir in
   let tmpdir = Server_workdirs.tmpdir logdir in
-  let switches = List.map Intf.Switch.name switches in
-  let* () = Server_workdirs.logdir_move ~switches logdir in
+  let names = List.map Intf.Switch.name switches in
+  let* () = Server_workdirs.logdir_move ~names logdir in
   let* () = Oca_lib.rm_rf metadatadir in
   let* () = Lwt_unix.rename (Fpath.to_string tmpmetadatadir) (Fpath.to_string metadatadir) in
   Oca_lib.rm_rf tmpdir

--- a/server/backend/check.ml
+++ b/server/backend/check.ml
@@ -356,8 +356,8 @@ fi |} pkg pkg pkg (Server_configfile.platform_distribution conf)
 
 let run_job ~cap ~conf ~pool ~debug ~stderr ~base_obuilder ~extra_repos ~switch ~num logdir pkg =
   Lwt_pool.use pool begin fun () ->
-    let* () = Lwt_io.write_line stderr ("["^num^"] Checking "^pkg^" on "^Intf.Switch.name switch^"…") in
     let name = Intf.Switch.name switch in
+    let* () = Lwt_io.write_line stderr ("["^num^"] Checking "^pkg^" on "^name^"…") in
     let logfile = Server_workdirs.tmplogfile ~pkg ~name logdir in
     let* v =
       Lwt_io.with_file ~flags:Unix.[O_WRONLY; O_CREAT; O_TRUNC] ~perm:0o640 ~mode:Lwt_io.Output (Fpath.to_string logfile) (fun stdout ->

--- a/server/backend/check.ml
+++ b/server/backend/check.ml
@@ -454,15 +454,16 @@ let get_obuilder ~conf ~cache ~opam_repo ~opam_repo_commit ~extra_repos switch =
         (Intf.Compiler.to_string (Intf.Switch.compiler switch));
       run ~network "opam update --depexts";
     ] @
-    (* TODO: Should this be removed now that it is part of the base docker images? What about macOS? *)
-    (* TODO: this is wonky because it assumes the version of the compiler from the switch name which is arbitrary *)
-    (if OpamVersionCompare.compare (Intf.Switch.name switch) "4.08" < 0 then
-       [run ~cache ~network "opam install -y ocaml-secondary-compiler"]
-       (* NOTE: See https://github.com/ocaml/opam-repository/pull/15404
-                and https://github.com/ocaml/opam-repository/pull/15642 *)
-     else
-       []
-    ) @
+    (
+      (* TODO: Should this be removed now that it is part of the base docker images? What about macOS? *)
+      let four_oh_eight = Intf.Compiler.from_string "4.08" in
+      if Intf.Compiler.compare (Intf.Switch.compiler switch) four_oh_eight < 0 then
+         [run ~cache ~network "opam install -y ocaml-secondary-compiler"]
+         (* NOTE: See https://github.com/ocaml/opam-repository/pull/15404
+                  and https://github.com/ocaml/opam-repository/pull/15642 *)
+       else
+         [])
+    @
     (match Server_configfile.extra_command conf with
      | Some c -> [run ~cache ~network "%s" c]
      | None -> []


### PR DESCRIPTION
This PR clears up the names in `Intf.Switch` which mixes up the name of the switch and the name of the compiler. This lead to the issue that the temporary directories are named after the compiler versions, when it would be better to use the name of the switch to index into the file system. That way the same compiler can be used to build using OPAM and Dune as long as the switch name differs.

Obsoletes and incorporates #100.