### PR TITLE
Use Dune to determine depexts

### DIFF
--- a/server/backend/check.ml
+++ b/server/backend/check.ml
@@ -346,8 +346,7 @@ fi |} pkg pkg pkg (Server_configfile.platform_distribution conf)
 
         (* attempt to install depexts after a lockfile solution has been created *)
         (* need to use dune for it as opam does not pick up depopts and dune does. *)
-        Printf.sprintf "%s dune show depexts > /tmp/packages-dune-determined-depexts" dune_path;
-        "xargs sudo apt-get install -y < /tmp/packages-dune-determined-depexts";
+        Printf.sprintf "sudo apt-get install -y $(%s dune show depexts)" dune_path;
 
         (* avoid invalid dependency hash errors by removing the hash *)
         "grep -v dependency_hash dune.lock/lock.dune > /tmp/lock.dune";

--- a/server/backend/check.ml
+++ b/server/backend/check.ml
@@ -173,8 +173,7 @@ let failure_kind_dune logfile =
     let rec lookup res =
       let* line = Lwt_io.read_line_opt ic in
       match line with
-      | Some "opam-health-check: Solve failed"
-      | Some "opam-health-check: Depext unsolvable" -> Lwt.return `NotAvailable
+      | Some "opam-health-check: Solve failed" -> Lwt.return `NotAvailable
       | Some "opam-health-check: Build failed" -> Lwt.return `Failure
       | Some _ -> lookup res
       | None -> Lwt.return res


### PR DESCRIPTION
The issue here is that OPAM does not install depopts by default and even despite #102 picking depopts explicitely this only works if the depopts are in the repo. E.g. if a package depends on a package that has a depopt itself, it won't be detected by #102 and OPAM won't suggest the `depext`. However, Dune will pick it when locking and then fail.

Thus this code changes the logic, so Dune locks a solution first and is then used to output the packages that need to be installed.