### PR TITLE
Fix compilation of dune-sites by reinstating site information

### DIFF
--- a/server/backend/check.ml
+++ b/server/backend/check.ml
@@ -278,8 +278,9 @@ let install_remove_packages =
 
 let remove_packages =
   String.concat " && " [
-    "/tmp/sexp/_opam/bin/sexp change '(try (rewrite (package @X) OPAM-HEALTH-CHECK-DROP))' < dune-project | grep -v OPAM-HEALTH-CHECK-DROP > dune-project-new";
-    "mv dune-project-new dune-project";
+    "/tmp/sexp/_opam/bin/sexp change '(try (rewrite (package @X) OPAM-HEALTH-CHECK-DROP))' < dune-project | grep -v OPAM-HEALTH-CHECK-DROP > dune-project-no-pkg";
+    "mv dune-project dune-project-pkg";
+    "mv dune-project-no-pkg dune-project";
   ]
 
 let run_script ~conf ~switch ~extra_repos pkg =
@@ -351,6 +352,11 @@ fi |} pkg pkg pkg (Server_configfile.platform_distribution conf)
         (* avoid invalid dependency hash errors by removing the hash *)
         "grep -v dependency_hash dune.lock/lock.dune > /tmp/lock.dune";
         "mv /tmp/lock.dune dune.lock/lock.dune";
+
+        (* now that locking is done, reinstate the original dune-project which has package & sites information *)
+        "mv dune-project-pkg dune-project";
+
+        (* finally, build *)
         Printf.sprintf {|%s dune build --release --only-packages $(cat /tmp/packages-for-dune) || (echo "opam-health-check: Build failed" && exit 1)|} dune_path
       ]])
 


### PR DESCRIPTION
As I was writing that we don't support `dune-site` because to read the dependencies out of `opam` files we need to delete the `package` stanzas out of `dune-project` it hit me that we probably can reinstate the original `dune-project` file (with the sites declarations) after the `dune pkg lock` because afterwards Dune doesn't care about the dependencies anymore.

This should work as long as the packages for which `.opam` files exist and the `package` stanzas align. Given we do our best to determine these by reading them from the tarball and `dune-project`, I think this should be the case for all packages.

I've tested it against `camomile.2.0.0` (one of the [packages that fail due to sites](https://dune.check.ci.dev/?comp=5.3-dune&comp=5.3-opam&available=5.3-dune&available=5.3-opam&show-only=bad&show-diff-only=true&show-latest-only=true&sort-by-revdeps=true&maintainers=&logsearch=doesn%27t+define+a+site&logsearch_comp=5.3-dune)) and at least locally it seems to work and solve the issue.